### PR TITLE
JSON format overhaul

### DIFF
--- a/data/STRchive-database.json
+++ b/data/STRchive-database.json
@@ -7,61 +7,84 @@
         "stop_hg19":94884000,
         "start_t2t":94266545,
         "stop_t2t":94266567,
-        "notes_t2t":null,
         "id":"OPDM_ABCD3",
         "disease_id":"OPDM",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCC",
-        "pathogenic_motif_reference_orientation":"GCC",
-        "pathogenic_motif_gene_orientation":"CCG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Oculopharyngodistal myopathy",
         "gene":"ABCD3",
         "flank_motif":null,
         "locus_structure":"(GCC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
-        "location_in_gene":null,
-        "normal":"3-44",
-        "normal_min":3.0,
-        "normal_max":44.0,
-        "intermediate":null,
+        "location_in_gene":"5' UTR",
+        "benign_min":3.0,
+        "benign_max":44.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"118-694",
         "pathogenic_min":118.0,
         "pathogenic_max":694.0,
         "ref_copies":7.7,
-        "repeatunitlen":3,
-        "age_onset":"Typical: 24-30; Range: 10-50 (doi.org\/10.1101\/2023.10.09.23296582)",
+        "motif_len":3,
+        "age_onset":"Typical: 24-30; Range: 10-50 (doi.org/10.1101/2023.10.09.23296582)",
         "age_onset_min":10,
         "age_onset_max":50,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":null,
-        "Mechanism":null,
-        "Mechanism_detail":null,
-        "Mechanism_source":null,
-        "source":"https:\/\/doi.org\/10.1101\/2023.10.09.23296582",
-        "notes":null,
+        "mechanism":null,
+        "mechanism_detail":null,
+        "source":[
+            "https://doi.org/10.1101/2023.10.09.23296582"
+        ],
         "details":null,
-        "width":null,
-        "OMIM":null,
-        "Prevalence":null,
-        "Prevalence_details":"Unknown",
-        "STRipy_gene":null,
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":"0025193",
-        "Year":2023.0,
-        "MedGen":"320250",
-        "Orphanet":"98897",
-        "GARD":"12592",
-        "WebSTR_hg38":"1164141; 6329150",
-        "WebSTR_hg19":"STR_58687"
+        "omim":[],
+        "prevalence":null,
+        "prevalence_details":"Found in individuals of European ancestry [pmid:38876750]",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[
+            "0025193"
+        ],
+        "year":2023.0,
+        "medgen":[
+            "320250"
+        ],
+        "orphanet":[
+            "98897"
+        ],
+        "gard":[
+            "12592"
+        ],
+        "malacard":[],
+        "webstr_hg38":[
+            "1164141",
+            "6329150"
+        ],
+        "webstr_hg19":[
+            "STR_58687"
+        ],
+        "tr_gnomad":[
+            "TR5671"
+        ],
+        "disease_description":"Oculopharyngodistal myopathy (OPDM) is a rare, adult-onset hereditary muscle disease. People with OPDM present with progressive eye and throat (pharyngeal) problems and involvement of the muscles of the lower legs and arms. Symptoms may include eyelid drooping (ptosis), swallowing difficulty, hoarse and nasal voice, leg and arm weakness, as well as muscle wasting in the face and in the legs and arms. Many people have respiratory problems due to respiratory muscle weakness. In rare cases, there is also hearing loss, as well as severe weakness in muscles of the forearms and thighs. As the disease progresses, other muscles may be affected. A blood exam may show an increased creatine kinase level and an abnormal EMG. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -71,61 +94,91 @@
         "stop_hg19":147582273,
         "start_t2t":146765191,
         "stop_t2t":146765342,
-        "notes_t2t":"(GCC)51.3",
         "id":"FRAXE_AFF2",
         "disease_id":"FRAXE",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCC",
-        "pathogenic_motif_reference_orientation":"GCC",
-        "pathogenic_motif_gene_orientation":"CCG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Fragile X syndrome, FRAXE type",
         "gene":"AFF2",
         "flank_motif":null,
         "locus_structure":"(GCC)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"5' UTR",
-        "location_in_gene":"5\u2019 Region",
-        "normal":"4-39",
-        "normal_min":4.0,
-        "normal_max":39.0,
-        "intermediate":null,
+        "location_in_gene":null,
+        "benign_min":4.0,
+        "benign_max":39.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"200-2000",
         "pathogenic_min":200.0,
         "pathogenic_max":2000.0,
         "ref_copies":50.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 2-10; Range: 1-10 (developmental delays without physical features can make onset difficult to detect until schooling)",
         "age_onset_min":1,
         "age_onset_max":10,
         "typ_age_onset_min":2.0,
         "typ_age_onset_max":10.0,
         "novel":"ref",
-        "Mechanism":"LOF, reduced gene expression",
-        "Mechanism_detail":"Loss of function via transcriptional silencing",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg1691) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Mirkin 2007, OMIM, GeneReviews NBK535148",
-        "notes":null,
+        "mechanism":"LOF, reduced gene expression",
+        "mechanism_detail":"Loss of function via transcriptional silencing (doi.org/10.1038/nrg1691) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Mirkin 2007",
+            "OMIM",
+            "GeneReviews NBK535148"
+        ],
         "details":null,
-        "width":148.0,
-        "OMIM":"309548",
-        "Prevalence":"2\/50000",
-        "Prevalence_details":"1-4\/100,000 males (https:\/\/medlineplus.gov\/genetics\/condition\/fragile-xe-syndrome); 1\/50-100,000 males, more than 50 families (PMID: 11246464)",
-        "STRipy_gene":"AFF2",
-        "gnomAD_gene":"AFF2",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010659",
-        "Year":1993.0,
-        "MedGen":"155512",
-        "Orphanet":"100973",
-        "GARD":"2378",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":null
+        "omim":[
+            "309548"
+        ],
+        "prevalence":"2/50000",
+        "prevalence_details":"1-4/100,000 males (https://medlineplus.gov/genetics/condition/fragile-xe-syndrome); 1/50-100,000 males, more than 50 families [pmid:11246464]. Found in populations around the globe, including in the UK, US, Canada, Taiwan, Germany, Greece, Cyprus, Spain, and Finland [pmid:11246464]",
+        "stripy":[
+            "AFF2"
+        ],
+        "gnomad":[
+            "AFF2"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010659"
+        ],
+        "year":1993.0,
+        "medgen":[
+            "155512"
+        ],
+        "orphanet":[
+            "100973"
+        ],
+        "gard":[
+            "2378"
+        ],
+        "malacard":[
+            "INT399"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR173976"
+        ],
+        "disease_description":"A nonsyndromic X-linked mental retardation (NS-XLMR) characterized by mild intellectual deficit. FRAXE is the most common form of NS-XLMR. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr2",
@@ -135,61 +188,78 @@
         "stop_hg19":100721286,
         "start_t2t":100563686,
         "stop_t2t":100563738,
-        "notes_t2t":"(GCC)17.7",
         "id":"FRA2A_AFF3",
         "disease_id":"FRA2A",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GCC",
-        "pathogenic_motif_reference_orientation":"GCC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Intellectual disability associated with fragile site FRA2A",
         "gene":"AFF3",
         "flank_motif":null,
         "locus_structure":"(GCC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":"Intron ",
-        "normal":"3-20",
-        "normal_min":3.0,
-        "normal_max":20.0,
-        "intermediate":null,
+        "location_in_gene":"Intron 3",
+        "benign_min":3.0,
+        "benign_max":20.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"300",
         "pathogenic_min":300.0,
         "pathogenic_max":300.0,
         "ref_copies":8.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Early childhood (small sample size) (PMID: 24763282)",
         "age_onset_min":1,
         "age_onset_max":7,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Decreased gene expression, methylation",
-        "Mechanism_detail":"\"silencing of the FMR2 gene as a consequence of a CCG expansion located upstream of this gene\"",
-        "Mechanism_source":"malacard",
-        "source":"https:\/\/doi.org\/10.1038\/s41580-021-00382-6, PMC3998887",
-        "notes":"Path threshold may actually be higher than 300, assay was not sensitive enough",
-        "details":null,
-        "width":25.0,
-        "OMIM":"601464",
-        "Prevalence":null,
-        "Prevalence_details":"1\/862 (1\/654-1266) population prevalence of methylated AFF3 expansions (mild cognitive disability) https:\/\/www.medrxiv.org\/content\/10.1101\/2023.05.03.23289461v1.full.pdf",
-        "STRipy_gene":null,
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":null,
-        "Year":2014.0,
-        "MedGen":null,
-        "Orphanet":null,
-        "GARD":null,
-        "WebSTR_hg38":"288936",
-        "WebSTR_hg19":null
+        "mechanism":"Decreased gene expression, methylation",
+        "mechanism_detail":"Silencing of the FMR2 gene as a consequence of a CCG expansion located upstream of this gene (Malacard)",
+        "source":[
+            "https://doi.org/10.1038/s41580-021-00382-6",
+            "PMC3998887"
+        ],
+        "details":"Pathogenic threshold may be higher than 300 as this was the largest allele that could be accurately sized by the assay.",
+        "omim":[
+            "601464"
+        ],
+        "prevalence":null,
+        "prevalence_details":"1/862 (1/654-1266) population prevalence of methylated AFF3 expansions (mild cognitive disability) https://www.medrxiv.org/content/10.1101/2023.05.03.23289461v1.full.pdf . Clinical cases have been observed in South Australia (PMID: 24763282)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[],
+        "year":2014.0,
+        "medgen":[],
+        "orphanet":[],
+        "gard":[],
+        "malacard":[
+            "KNS007"
+        ],
+        "webstr_hg38":[
+            "288936"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR252468"
+        ],
+        "disease_description":"These expansions are associated with intellectual disability and clinical phenotypes such as delayed motor development or delays in speech/language (PMID: 24763282)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -199,61 +269,99 @@
         "stop_hg19":66765261,
         "start_t2t":65975148,
         "stop_t2t":65975250,
-        "notes_t2t":"(GCA)33.3",
         "id":"SBMA_AR",
         "disease_id":"SBMA",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCA",
-        "pathogenic_motif_reference_orientation":"GCA",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinal and bulbar muscular atrophy, Kennedy Disease",
         "gene":"AR",
         "flank_motif":null,
         "locus_structure":"(GCA)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"9\u201334",
-        "normal_min":9.0,
-        "normal_max":34.0,
-        "intermediate":"36-37",
+        "benign_min":9.0,
+        "benign_max":34.0,
         "intermediate_min":36.0,
         "intermediate_max":37.0,
-        "pathogenic":"38\u201368",
         "pathogenic_min":38.0,
         "pathogenic_max":68.0,
         "ref_copies":34.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 20-49 (OMIM), Range: 8(PMID: 15851746)-78 (PMID: 19227892)",
         "age_onset_min":8,
         "age_onset_max":78,
         "typ_age_onset_min":20.0,
         "typ_age_onset_max":49.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine",
-        "Mechanism_detail":"Polyglutamine",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x, doi.org\/10.1016\/j.neurol.2017.03.019, doi.org\/10.1016\/j.pneurobio.2012.05.007, doi.org\/10.1111\/odi.12121, DOI: 10.1007\/s00415-018-8968-7, DOI: 10.1007\/s12031-015-0684-5",
-        "notes":"Possibility that contractions may play a role in disease (PMID: 10398229). May be subclinical in females (PMID: 34922802). Interruptions are not found and thus appear not to play a role in disease (PMID: 24041967). Can be clinically heterogeneous even within the same family (PMID: 20184516); may present with clinical heterogeneity.",
-        "details":"Expansions larger than the pathogenic threshold in the AR gene should be evaluated carefully. Interruptions have not been observed in patient cases and it has been proposed that longer alleles with interruptions may not be pathogenic (PMID: 24041967). Expansions are also detected ten-fold more often in a general population than would be expected by disease prevalence  (PMID: 36797998). Clinical evaluation and phenotypic matching may be necessary to determine diagnosis even in the presence of a pure expanded allele. AR was the first triplet disease to be discovered (doi:10.1001\/archneur.61.8.1324)",
-        "width":102.0,
-        "OMIM":"313200",
-        "Prevalence":"1\/30000",
-        "Prevalence_details":"1-2\/100,000 (population-specific, higher in Finnish population, Canadian population) (PMID: 37628685); 1\/30,000  (Orphanet) ; mutation frequency of 1:3182 10x more frequent than reported disease prevalence of 1 in 30,000 (PMID: 36797998); Tang et al., 2017: 0.67-2.5\/100,000",
-        "STRipy_gene":"AR",
-        "gnomAD_gene":"AR",
-        "GeneReviews":"NBK1333",
-        "Mondo":"0010735",
-        "Year":1991.0,
-        "MedGen":"333282",
-        "Orphanet":"481",
-        "GARD":"6818",
-        "WebSTR_hg38":"859199",
-        "WebSTR_hg19":null
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x",
+            "doi.org/10.1016/j.neurol.2017.03.019",
+            "doi.org/10.1016/j.pneurobio.2012.05.007",
+            "doi.org/10.1111/odi.12121",
+            "DOI: 10.1007/s00415-018-8968-7",
+            "DOI: 10.1007/s12031-015-0684-5"
+        ],
+        "details":"Expansions larger than the pathogenic threshold in the AR gene should be evaluated carefully. Interruptions have not been observed in patient cases and it has been proposed that longer alleles with interruptions may not be pathogenic (PMID: 24041967). Expansions are also detected ten-fold more often in a general population than would be expected by disease prevalence (PMID: 36797998). Clinical evaluation and phenotypic matching may be necessary to determine diagnosis even in the presence of a pure expanded allele. It has been proposed that contractions may play a role in disease (PMID: 10398229). May be subclinical in females (PMID: 34922802). Can be clinically heterogeneous even within the same family (PMID: 20184516). AR was the first triplet disease to be discovered (doi:10.1001/archneur.61.8.1324)",
+        "omim":[
+            "313200"
+        ],
+        "prevalence":"1/30000",
+        "prevalence_details":"1-2/100,000 (population-specific, higher in Finnish population, Canadian population) (PMID: 37628685); 1/30,000  (Orphanet) ; mutation frequency of 1:3182 10x more frequent than reported disease prevalence of 1 in 30,000 (PMID: 36797998); Tang et al., 2017: 0.67-2.5/100,000 . Only documented in patients with European/Asian ancestry, including Scandinavian, English, Belgian, French, Italian, German, Polish, Spanish, Swiss, Moroccan, Turkish, Chinese, Japanese (more common because of a founder effect), Korean, and Vietnamese populations (NBK1333)",
+        "stripy":[
+            "AR"
+        ],
+        "gnomad":[
+            "AR"
+        ],
+        "genereviews":[
+            "NBK1333"
+        ],
+        "mondo":[
+            "0010735"
+        ],
+        "year":1991.0,
+        "medgen":[
+            "333282"
+        ],
+        "orphanet":[
+            "481"
+        ],
+        "gard":[
+            "6818"
+        ],
+        "malacard":[
+            "SPN404"
+        ],
+        "webstr_hg38":[
+            "859199"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR169377"
+        ],
+        "disease_description":"Kennedy's disease, also known as bulbospinal muscular atrophy (BSMA), is a rare X-linked recessive motor neuron disease characterized by proximal and bulbar muscle wasting. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -263,61 +371,96 @@
         "stop_hg19":25031814,
         "start_t2t":24597886,
         "stop_t2t":24597934,
-        "notes_t2t":"(GCC)14.7",
         "id":"EIEE1_ARX",
         "disease_id":"EIEE1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Early-infantile epileptic encephalopathy",
         "gene":"ARX",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"Coding",
-        "location_in_gene":"Exon 2",
-        "normal":"10-16",
-        "normal_min":10.0,
-        "normal_max":16.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 2, aa 110-115",
+        "benign_min":10.0,
+        "benign_max":16.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"17-27",
         "pathogenic_min":17.0,
         "pathogenic_max":27.0,
         "ref_copies":14.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 0 (PMID: 21204215, PMID: 9307258, OMIM); Range: 0-4 (Childhood epilepsy, cognitive disability,  \u223c70% of cases infantile spasms -->  seizures by 3 or 4 years re: PMID: 19587282)",
         "age_onset_min":0,
         "age_onset_max":4,
         "typ_age_onset_min":0.0,
         "typ_age_onset_max":0.0,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"GeneReviews NBK535148, OMIM",
-        "notes":"Exon 2 aa 110-115",
-        "details":"ARX expansions result in a range of phenotypes such as Partington syndrome (OMIM 309510), Early Infantile Epileptic Encephalopathy (OMIM 308350), Agenesis of Corpus Callosum with Abnormal Genitalia (OMIM 300004), and X-Linked Lissencephaly with Ambiguous Genitalia (OMIM 300215) as described in 10.1002\/mgg3.133 and 10.1002\/humu.21288",
-        "width":43.0,
-        "OMIM":"308350; 300419; 300215",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown",
-        "STRipy_gene":"ARX_1",
-        "gnomAD_gene":"ARX_1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010632",
-        "Year":null,
-        "MedGen":"483052",
-        "Orphanet":"182079",
-        "GARD":"15298",
-        "WebSTR_hg38":"843651",
-        "WebSTR_hg19":"STR_1542607"
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "GeneReviews NBK535148",
+            "OMIM"
+        ],
+        "details":"ARX expansions result in a range of phenotypes such as Partington syndrome (OMIM 309510), Early Infantile Epileptic Encephalopathy (OMIM 308350), Agenesis of Corpus Callosum with Abnormal Genitalia (OMIM 300004), and X-Linked Lissencephaly with Ambiguous Genitalia (OMIM 300215) as described in 10.1002/mgg3.133 and 10.1002/humu.21288",
+        "omim":[
+            "308350",
+            "300419",
+            "300215"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Found in individuals of multiple ethnicities, including European and Asian ancestry (PMID: 12874418)",
+        "stripy":[
+            "ARX_1"
+        ],
+        "gnomad":[
+            "ARX_1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010632"
+        ],
+        "year":null,
+        "medgen":[
+            "483052"
+        ],
+        "orphanet":[
+            "182079"
+        ],
+        "gard":[
+            "15298"
+        ],
+        "malacard":[
+            "ERL057"
+        ],
+        "webstr_hg38":[
+            "843651"
+        ],
+        "webstr_hg19":[
+            "STR_1542607"
+        ],
+        "tr_gnomad":[
+            "TR167317"
+        ],
+        "disease_description":"Developmental and epileptic encephalopathy-1 (DEE1) is a severe form of epilepsy characterized by frequent tonic seizures or spasms beginning in infancy with a specific EEG finding of suppression-burst patterns, characterized by high-voltage bursts alternating with almost flat suppression phases. (OMIM: 308350)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -327,61 +470,90 @@
         "stop_hg19":25031682,
         "start_t2t":24597767,
         "stop_t2t":24597799,
-        "notes_t2t":"(GGCCGCGGCGGCCGC)2.2",
         "id":"PRTS_ARX",
         "disease_id":"PRTS",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Partington syndrome",
         "gene":"ARX",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"Coding",
-        "location_in_gene":"Exon 2",
-        "normal":"12",
-        "normal_min":12.0,
-        "normal_max":12.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 2, aa 144-155",
+        "benign_min":12.0,
+        "benign_max":12.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"20",
         "pathogenic_min":20.0,
         "pathogenic_max":20.0,
         "ref_copies":12.0,
-        "repeatunitlen":3,
-        "age_onset":"Typical: 1-3; Range: 0-4 (OMIM); Mildness can make diagnosis difficult (particularly mild\/absent in females) ",
+        "motif_len":3,
+        "age_onset":"Typical: 1-3; Range: 0-4 (OMIM); Mildness can make diagnosis difficult (particularly mild/absent in females) ",
         "age_onset_min":0,
         "age_onset_max":4,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(OMIM) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"GeneReviews NBK535148, OMIM",
-        "notes":"Novel, Exon 2 aa 144-155",
-        "details":"ARX expansions result in a range of phenotypes such as Partington syndrome (OMIM 309510), Early Infantile Epileptic Encephalopathy (OMIM 308350), Agenesis of Corpus Callosum with Abnormal Genitalia (OMIM 300004), and X-Linked Lissencephaly with Ambiguous Genitalia (OMIM 300215) as described in 10.1002\/mgg3.133 and 10.1002\/humu.21288",
-        "width":35.0,
-        "OMIM":"309510",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown",
-        "STRipy_gene":"ARX_2",
-        "gnomAD_gene":"ARX_2",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010654",
-        "Year":null,
-        "MedGen":"163237",
-        "Orphanet":"94083",
-        "GARD":"4235",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":null
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (OMIM) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "GeneReviews NBK535148",
+            "OMIM"
+        ],
+        "details":"ARX expansions result in a range of phenotypes such as Partington syndrome (OMIM 309510), Early Infantile Epileptic Encephalopathy (OMIM 308350), Agenesis of Corpus Callosum with Abnormal Genitalia (OMIM 300004), and X-Linked Lissencephaly with Ambiguous Genitalia (OMIM 300215) as described in 10.1002/mgg3.133 and 10.1002/humu.21288",
+        "omim":[
+            "309510"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Limited clinical cases of predominantly European ancestry, such as Welsh/Belgian (OMIM: 309510)",
+        "stripy":[
+            "ARX_2"
+        ],
+        "gnomad":[
+            "ARX_2"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010654"
+        ],
+        "year":null,
+        "medgen":[
+            "163237"
+        ],
+        "orphanet":[
+            "94083"
+        ],
+        "gard":[
+            "4235"
+        ],
+        "malacard":[
+            "PRT003"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR167316"
+        ],
+        "disease_description":"A rare neurological condition that is primarily characterized by mild to moderate intellectual disability and dystonia of the hands. Other signs and symptoms may include dysarthria, behavioral abnormalities, recurrent seizures and/or an unusual gait (style of walking). Partington syndrome usually occurs in males; when it occurs in females, the signs and symptoms are often less severe. It is caused by changes (mutations) in the ARX gene and is inherited in an X-linked recessive manner. Treatment is based on the signs and symptoms present in each person. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr12",
@@ -391,61 +563,99 @@
         "stop_hg19":7045938,
         "start_t2t":6947904,
         "stop_t2t":6947941,
-        "notes_t2t":"(CAG)12.7",
         "id":"DRPLA_ATN1",
         "disease_id":"DRPLA",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CAG",
-        "pathogenic_motif_reference_orientation":"CAG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Dentatorubral-Pallidoluysian Atrophy",
         "gene":"ATN1",
         "flank_motif":null,
         "locus_structure":"(CAG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 5",
-        "normal":"3\u201335",
-        "normal_min":3.0,
-        "normal_max":35.0,
-        "intermediate":null,
+        "benign_min":3.0,
+        "benign_max":35.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"48-93",
         "pathogenic_min":48.0,
         "pathogenic_max":93.0,
         "ref_copies":19.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 20-40 (PMID: 6808417, NBK1491); Range: 0 (PMID: 11160976) - 72 (NBK1491)",
         "age_onset_min":0,
         "age_onset_max":72,
         "typ_age_onset_min":20.0,
         "typ_age_onset_max":40.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine",
-        "Mechanism_detail":"Polyglutamine",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x",
-        "notes":"Interruptions: CAA (PMID: 35245110)",
-        "details":null,
-        "width":58.0,
-        "OMIM":"125370",
-        "Prevalence":"4.5\/1000000",
-        "Prevalence_details":"2-7\/1,000,000",
-        "STRipy_gene":"ATN1",
-        "gnomAD_gene":"ATN1",
-        "GeneReviews":"NBK1491",
-        "Mondo":"0007435",
-        "Year":1994.0,
-        "MedGen":"155630",
-        "Orphanet":"101",
-        "GARD":"5643",
-        "WebSTR_hg38":"5050156",
-        "WebSTR_hg19":"Expansion_ATN1\/DRPLA"
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x"
+        ],
+        "details":"CAA interruptions have been observed (PMID: 35245110)",
+        "omim":[
+            "125370"
+        ],
+        "prevalence":"4.5/1000000",
+        "prevalence_details":"2-7/1,000,000. More prevalent in Japanese populations, also reported in North America, South America, Europe, and Australia (NBK1491)",
+        "stripy":[
+            "ATN1"
+        ],
+        "gnomad":[
+            "ATN1"
+        ],
+        "genereviews":[
+            "NBK1491"
+        ],
+        "mondo":[
+            "0007435"
+        ],
+        "year":1994.0,
+        "medgen":[
+            "155630"
+        ],
+        "orphanet":[
+            "101"
+        ],
+        "gard":[
+            "5643"
+        ],
+        "malacard":[
+            "DNT005"
+        ],
+        "webstr_hg38":[
+            "5050156"
+        ],
+        "webstr_hg19":[
+            "Expansion_ATN1/DRPLA"
+        ],
+        "tr_gnomad":[
+            "TR114246"
+        ],
+        "disease_description":"Dentatorubral pallidoluysian atrophy (DRPLA) is a rare subtype of type I autosomal dominant cerebellar ataxia (ADCA type I). It is characterized by involuntary movements, ataxia, epilepsy, mental disorders, cognitive decline and prominent anticipation. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia",
+            "epilepsy"
+        ]
     },
     {
         "chrom":"chr6",
@@ -455,61 +665,98 @@
         "stop_hg19":16327955,
         "start_t2t":16200189,
         "stop_t2t":16200282,
-        "notes_t2t":"(TGC)31.1",
         "id":"SCA1_ATXN1",
         "disease_id":"SCA1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CTG",
-        "pathogenic_motif_reference_orientation":"CTG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar Ataxia Type 1",
         "gene":"ATXN1",
         "flank_motif":null,
         "locus_structure":"(CTG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 8",
-        "normal":"6\u201335",
-        "normal_min":6.0,
-        "normal_max":35.0,
-        "intermediate":"36-38",
+        "benign_min":6.0,
+        "benign_max":35.0,
         "intermediate_min":36.0,
         "intermediate_max":38.0,
-        "pathogenic":"39\u201391",
         "pathogenic_min":39.0,
         "pathogenic_max":91.0,
         "ref_copies":30.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 20-39 (UptoDate); Range: 6(PMID: 3165612)-63 (PMID: 8825276)",
         "age_onset_min":6,
         "age_onset_max":63,
         "typ_age_onset_min":20.0,
         "typ_age_onset_max":39.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine",
-        "Mechanism_detail":"Polyglutamine",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK1184, s40478-021-01201-x",
-        "notes":"Interruptions: CAT (PMID: 35245110)",
-        "details":null,
-        "width":90.0,
-        "OMIM":"164400",
-        "Prevalence":"1.5\/100000",
-        "Prevalence_details":"1-2\/100,000",
-        "STRipy_gene":"ATXN1",
-        "gnomAD_gene":"ATXN1",
-        "GeneReviews":"NBK1184",
-        "Mondo":"0008119",
-        "Year":1993.0,
-        "MedGen":"155703",
-        "Orphanet":"98755",
-        "GARD":"4071",
-        "WebSTR_hg38":"5767842",
-        "WebSTR_hg19":"Expansion_SCA1\/ATXN1"
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK1184",
+            "s40478-021-01201-x"
+        ],
+        "details":"CAT interruptions have been observed (PMID: 35245110)",
+        "omim":[
+            "164400"
+        ],
+        "prevalence":"1.5/100000",
+        "prevalence_details":"1-2/100,000. Cases have been reported worldwide, although prevalences varies by ancestry/ethnicity (NBK1184)",
+        "stripy":[
+            "ATXN1"
+        ],
+        "gnomad":[
+            "ATXN1"
+        ],
+        "genereviews":[
+            "NBK1184"
+        ],
+        "mondo":[
+            "0008119"
+        ],
+        "year":1993.0,
+        "medgen":[
+            "155703"
+        ],
+        "orphanet":[
+            "98755"
+        ],
+        "gard":[
+            "4071"
+        ],
+        "malacard":[
+            "SPN294"
+        ],
+        "webstr_hg38":[
+            "5767842"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA1/ATXN1"
+        ],
+        "tr_gnomad":[
+            "TR63118"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 1 (SCA1) is a subtype of type I autosomal dominant cerebellar ataxia (ADCA type I) characterized by dysarthria, writing difficulties, limb ataxia, and commonly nystagmus and saccadic abnormalities. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr22",
@@ -519,61 +766,99 @@
         "stop_hg19":46191304,
         "start_t2t":46280060,
         "stop_t2t":46280129,
-        "notes_t2t":"(ATTCT)15.0",
         "id":"SCA10_ATXN10",
         "disease_id":"SCA10",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"ATTCT",
-        "pathogenic_motif_reference_orientation":"ATTCT",
-        "pathogenic_motif_gene_orientation":"ATTCT",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "ATTCT"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "ATTCT"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTCT"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar Ataxia Type 10",
         "gene":"ATXN10",
         "flank_motif":null,
         "locus_structure":"(ATTCT)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":"Intron 9\/11",
-        "normal":"10\u201332",
-        "normal_min":10.0,
-        "normal_max":32.0,
-        "intermediate":"280-850",
+        "location_in_gene":"Intron 9",
+        "benign_min":10.0,
+        "benign_max":32.0,
         "intermediate_min":280.0,
         "intermediate_max":850.0,
-        "pathogenic":"800-4500",
         "pathogenic_min":800.0,
         "pathogenic_max":4500.0,
         "ref_copies":14.0,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 12-48; Range: 11-83 (NBK1175)",
         "age_onset_min":11,
         "age_onset_max":83,
         "typ_age_onset_min":12.0,
         "typ_age_onset_max":48.0,
         "novel":"ref",
-        "Mechanism":"GOF (RNA)",
-        "Mechanism_detail":"Transdominant mechanism theorized",
-        "Mechanism_source":"(malacard), PMID: 38467784",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x",
-        "notes":"SCA10 expansions are frequently interrupted by ATCCT, ATCCC, ATTCC, ATTTCT, ATATTCT, ATTCTTCT, or ATTCTTCT; also interruptions of ATTGT, TTTCT, ATTTTCT, ATTCTCT (PMID: 36199580). Additional interruption ATGCT (PMID: 19234597). ATCCT interruption motif is associated with a higher prevalence of epileptic seizures [McFarland et al 2014].",
-        "details":null,
-        "width":69.0,
-        "OMIM":"603516",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown; >300 individuals (GeneReview)",
-        "STRipy_gene":"ATXN10",
-        "gnomAD_gene":"ATXN10",
-        "GeneReviews":"NBK1175",
-        "Mondo":"0011330",
-        "Year":2000.0,
-        "MedGen":"369786",
-        "Orphanet":"98761",
-        "GARD":"10474",
-        "WebSTR_hg38":"1027359; 4921433",
-        "WebSTR_hg19":"STR_909210"
+        "mechanism":"GOF (RNA)",
+        "mechanism_detail":"Transdominant mechanism theorized (malacard), PMID: 38467784",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x"
+        ],
+        "details":"SCA10 expansions are frequently interrupted by ATCCT, ATCCC, ATTCC, ATTTCT, ATATTCT, ATTCTTCT, or ATTCTTCT; also interruptions of ATTGT, TTTCT, ATTTTCT, ATTCTCT (PMID: 36199580). Additional interruption ATGCT (PMID: 19234597). ATCCT interruption motif is associated with a higher prevalence of epileptic seizures [McFarland et al 2014].",
+        "omim":[
+            "603516"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Unknown prevalence, >300 individuals (GeneReview). Cases have been identified in Mexico, Brazil, China, and Japan (NBK1175)",
+        "stripy":[
+            "ATXN10"
+        ],
+        "gnomad":[
+            "ATXN10"
+        ],
+        "genereviews":[
+            "NBK1175"
+        ],
+        "mondo":[
+            "0011330"
+        ],
+        "year":2000.0,
+        "medgen":[
+            "369786"
+        ],
+        "orphanet":[
+            "98761"
+        ],
+        "gard":[
+            "10474"
+        ],
+        "malacard":[
+            "SPN314"
+        ],
+        "webstr_hg38":[
+            "1027359",
+            "4921433"
+        ],
+        "webstr_hg19":[
+            "STR_909210"
+        ],
+        "tr_gnomad":[
+            "TR165509"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 10 (SCA10) is a subtype of type I autosomal dominant cerebellar ataxia (ADCA type I). It is characterized by slowly progressive cerebellar syndrome and epilepsy, sometimes mild pyramidal signs, peripheral neuropathy and neuropsychological disturbances (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr12",
@@ -583,61 +868,99 @@
         "stop_hg19":112036823,
         "start_t2t":111575873,
         "stop_t2t":111575940,
-        "notes_t2t":"(GCT)22.3",
         "id":"SCA2_ATXN2",
         "disease_id":"SCA2",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CTG",
-        "pathogenic_motif_reference_orientation":"CTG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar Ataxia Type 2",
         "gene":"ATXN2",
         "flank_motif":null,
         "locus_structure":"(CTG)*",
-        "Inheritance":"AD\/AR",
+        "inheritance":[
+            "AD",
+            "AR"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"14\u201331",
-        "normal_min":14.0,
-        "normal_max":31.0,
-        "intermediate":"32-34",
+        "benign_min":14.0,
+        "benign_max":31.0,
         "intermediate_min":32.0,
         "intermediate_max":34.0,
-        "pathogenic":"33\u2013200",
         "pathogenic_min":33.0,
         "pathogenic_max":200.0,
         "ref_copies":23.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 30-39 (GeneReview); Range: 2-86 (OMIM)",
         "age_onset_min":2,
         "age_onset_max":86,
         "typ_age_onset_min":30.0,
         "typ_age_onset_max":39.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine ",
-        "Mechanism_detail":"Polyglutamine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, GeneReviews NBK1275, s40478-021-01201-x",
-        "notes":"29\u201332 repeats: increased ALS risk, Interruptions: CAA, CGG, CGC. Parkinson disease, late-onset, susceptibility.",
-        "details":null,
-        "width":69.0,
-        "OMIM":"183090",
-        "Prevalence":"1.5\/100000",
-        "Prevalence_details":"1-2\/100,000 (Tang et al., 2017) (population dependent)",
-        "STRipy_gene":"ATXN2",
-        "gnomAD_gene":"ATXN2",
-        "GeneReviews":"NBK1275",
-        "Mondo":"0008458",
-        "Year":1996.0,
-        "MedGen":"155704",
-        "Orphanet":"98756",
-        "GARD":"4072",
-        "WebSTR_hg38":"598560; 5117050",
-        "WebSTR_hg19":"Expansion_SCA2\/ATXN2"
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "GeneReviews NBK1275",
+            "s40478-021-01201-x"
+        ],
+        "details":"29-32 repeats is associated with increased ALS risk. Interruptions observed: CAA, CGG, CGC. Parkinson disease, late-onset, susceptibility.",
+        "omim":[
+            "183090"
+        ],
+        "prevalence":"1.5/100000",
+        "prevalence_details":"1-2/100,000 (Tang et al., 2017) (population dependent). Cases have been found across ethnicities/ancestries, with population-dependent prevalence (NBK1275)",
+        "stripy":[
+            "ATXN2"
+        ],
+        "gnomad":[
+            "ATXN2"
+        ],
+        "genereviews":[
+            "NBK1275"
+        ],
+        "mondo":[
+            "0008458"
+        ],
+        "year":1996.0,
+        "medgen":[
+            "155704"
+        ],
+        "orphanet":[
+            "98756"
+        ],
+        "gard":[
+            "4072"
+        ],
+        "malacard":[
+            "SPN301"
+        ],
+        "webstr_hg38":[
+            "598560",
+            "5117050"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA2/ATXN2"
+        ],
+        "tr_gnomad":[
+            "TR120465"
+        ],
+        "disease_description":"A subtype of type I autosomal dominant cerebellar ataxia (ADCA type I) characterized by truncal ataxia, dysarthria, slowed saccades and less commonly ophthalmoparesis and chorea. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr14",
@@ -647,61 +970,99 @@
         "stop_hg19":92537397,
         "start_t2t":86300520,
         "stop_t2t":86300603,
-        "notes_t2t":"(CTG)28.0",
         "id":"SCA3_ATXN3",
         "disease_id":"SCA3, MJD",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CTG",
-        "pathogenic_motif_reference_orientation":"CTG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
-        "disease":"Spinocerebellar Ataxia Type 3\/Machado-Joseph Disease",
+        "reference_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
+        "disease":"Spinocerebellar Ataxia Type 3/Machado-Joseph Disease",
         "gene":"ATXN3",
         "flank_motif":null,
         "locus_structure":"(CTG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
-        "location_in_gene":"Second last exon",
-        "normal":"12\u201344",
-        "normal_min":12.0,
-        "normal_max":44.0,
-        "intermediate":"45-59",
+        "location_in_gene":"Exon 10",
+        "benign_min":12.0,
+        "benign_max":44.0,
         "intermediate_min":45.0,
         "intermediate_max":59.0,
-        "pathogenic":"60-87",
         "pathogenic_min":60.0,
         "pathogenic_max":87.0,
         "ref_copies":14.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 10-49 (GeneReview); 5-73 (GeneReview; PMID: 30414314)",
         "age_onset_min":5,
         "age_onset_max":73,
         "typ_age_onset_min":10.0,
         "typ_age_onset_max":49.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine ",
-        "Mechanism_detail":"Polyglutamine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x",
-        "notes":"Interruptions: CAA (PMID: 35245110); AAG is present in hg38 reference sequence",
-        "details":null,
-        "width":41.0,
-        "OMIM":"109150",
-        "Prevalence":"2.1\/100000",
-        "Prevalence_details":"1\u20135\/100,000, Tang et al., 2017; Most prevalence SCA subtype (NBK557816)",
-        "STRipy_gene":"ATXN3",
-        "gnomAD_gene":"ATXN3",
-        "GeneReviews":"NBK1196",
-        "Mondo":"0007182",
-        "Year":1994.0,
-        "MedGen":"9841",
-        "Orphanet":"98757",
-        "GARD":"6801",
-        "WebSTR_hg38":"5316666; 1481402",
-        "WebSTR_hg19":"Expansion_SCA3_MJD\/ATXN3"
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x"
+        ],
+        "details":"Interruptions: CAA (PMID: 35245110); AAG is present in hg38 reference sequence",
+        "omim":[
+            "109150"
+        ],
+        "prevalence":"2.1/100000",
+        "prevalence_details":"1-5/100,000, Tang et al., 2017; Most prevalent SCA subtype (NBK557816). Found worldwide across ancestries/ethnicities (NBK1196)",
+        "stripy":[
+            "ATXN3"
+        ],
+        "gnomad":[
+            "ATXN3"
+        ],
+        "genereviews":[
+            "NBK1196"
+        ],
+        "mondo":[
+            "0007182"
+        ],
+        "year":1994.0,
+        "medgen":[
+            "9841"
+        ],
+        "orphanet":[
+            "98757"
+        ],
+        "gard":[
+            "6801"
+        ],
+        "malacard":[
+            "MCH002"
+        ],
+        "webstr_hg38":[
+            "5316666",
+            "1481402"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA3_MJD/ATXN3"
+        ],
+        "tr_gnomad":[
+            "TR132758"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 3 (SCA3), also known as Machado-Joseph disease, is the most common subtype of type 1 autosomal dominant cerebellar ataxia (ADCA type 1), a neurodegenerative disorder, and is characterized by ataxia, external progressive ophthalmoplegia, and other neurological manifestations. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr3",
@@ -711,61 +1072,99 @@
         "stop_hg19":63898392,
         "start_t2t":63956303,
         "stop_t2t":63956334,
-        "notes_t2t":"(GCA)10.7",
         "id":"SCA7_ATXN7",
         "disease_id":"SCA7",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CAG",
-        "pathogenic_motif_reference_orientation":"CAG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar Ataxia Type 7",
         "gene":"ATXN7",
         "flank_motif":"(CAG)n(CCG)4",
         "locus_structure":"(CAG)*(CCG)+",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1, 2, or 3 (depending on isoform)",
-        "normal":"4\u201319",
-        "normal_min":4.0,
-        "normal_max":19.0,
-        "intermediate":"28-35",
+        "benign_min":4.0,
+        "benign_max":19.0,
         "intermediate_min":28.0,
         "intermediate_max":35.0,
-        "pathogenic":"34\u2013460",
         "pathogenic_min":34.0,
         "pathogenic_max":460.0,
         "ref_copies":10.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 4-48 (PMID: 20739808); Range: 0-65 (GeneReview)",
         "age_onset_min":0,
         "age_onset_max":65,
         "typ_age_onset_min":4.0,
         "typ_age_onset_max":48.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine ",
-        "Mechanism_detail":"Polyglutamine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x",
-        "notes":"Interruptions: CAA (PMID: 35245110)",
-        "details":null,
-        "width":31.0,
-        "OMIM":"164500",
-        "Prevalence":".999\/300000",
-        "Prevalence_details":"<1\/300,000 (GeneReview)",
-        "STRipy_gene":"ATXN7",
-        "gnomAD_gene":"ATXN7",
-        "GeneReviews":"NBK1256",
-        "Mondo":"0016163",
-        "Year":1996.0,
-        "MedGen":"156006",
-        "Orphanet":"94147",
-        "GARD":"20405",
-        "WebSTR_hg38":"4965588",
-        "WebSTR_hg19":"Expansion_SCA7\/ATXN7"
+        "mechanism":"Polyglutamine ",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x"
+        ],
+        "details":"Interruptions observed: CAA (PMID: 35245110)",
+        "omim":[
+            "164500"
+        ],
+        "prevalence":".999/300000",
+        "prevalence_details":"<1/300,000 (GeneReview). Predominantly found in those with North European and African ancestry(NBK1256)",
+        "stripy":[
+            "ATXN7"
+        ],
+        "gnomad":[
+            "ATXN7"
+        ],
+        "genereviews":[
+            "NBK1256"
+        ],
+        "mondo":[
+            "0016163"
+        ],
+        "year":1996.0,
+        "medgen":[
+            "156006"
+        ],
+        "orphanet":[
+            "94147"
+        ],
+        "gard":[
+            "20405"
+        ],
+        "malacard":[
+            "SPN291"
+        ],
+        "webstr_hg38":[
+            "4965588"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA7/ATXN7"
+        ],
+        "tr_gnomad":[
+            "TR31879",
+            "TR31880"
+        ],
+        "disease_description":"Spinocerebellar ataxia-7 (SCA7) is an autosomal dominant neurodegenerative disorder characterized by adult onset of progressive cerebellar ataxia associated with pigmental macular dystrophy. OMIM: 164500",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr13",
@@ -775,61 +1174,99 @@
         "stop_hg19":70713561,
         "start_t2t":69361244,
         "stop_t2t":69361271,
-        "notes_t2t":"(CTG)9.3",
         "id":"SCA8_ATXN8OS",
         "disease_id":"SCA8",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CTG",
-        "pathogenic_motif_reference_orientation":"CTG",
-        "pathogenic_motif_gene_orientation":"CTG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CTG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar Ataxia Type 8",
         "gene":"ATXN8OS",
         "flank_motif":"(CTA)10(CTG)n",
         "locus_structure":"(CTA)*(CTG)*",
-        "Inheritance":"AD",
-        "type":"3' UTR",
-        "location_in_gene":"Exon 5 or 3\u2019 UTR depending on transcript",
-        "normal":"15\u201350",
-        "normal_min":15.0,
-        "normal_max":50.0,
-        "intermediate":"50-70",
+        "inheritance":[
+            "AD"
+        ],
+        "type":"Coding/3' UTR",
+        "location_in_gene":"Exon 1 or 3\u2019 UTR depending on transcript",
+        "benign_min":15.0,
+        "benign_max":50.0,
         "intermediate_min":50.0,
         "intermediate_max":70.0,
-        "pathogenic":"71-1300",
         "pathogenic_min":71.0,
         "pathogenic_max":1300.0,
         "ref_copies":15.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 20-40; Range: 0-73 (GeneReview)",
         "age_onset_min":1,
         "age_onset_max":73,
         "typ_age_onset_min":20.0,
         "typ_age_onset_max":49.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine\/toxic gain-of-function; Unknown ",
-        "Mechanism_detail":"Polyglutamine\/toxic gain-of-function; Unknown ",
-        "Mechanism_source":"(OMIM) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x",
-        "notes":"Two genes span the CTG\/CAG repeat and are expressed in opposite directions: ATXN8, which encodes a nearly pure polyglutamine expansion protein in the CAG direction, and ATXN8OS (603680), which, when transcribed, produces a noncoding CUG expansion RNA (Moseley et al., 2006). Roda et al. suggested that the ATXN8 or ATXN8OS gene should not be evaluated in isolation as a candidate gene for spinocerebellar degenerative disease. CCG\u2022CGG interruptions in high\u2010penetrance SCA8 families increase RAN translation and protein toxicity (PMID: 34632710); 'Interruptions w\/in CTG\u00b7CAG expansion by 1 or more CCG\u00b7CGG, CTA\u00b7TAG, CTC\u00b7GAG, CCA\u00b7TGG, or CTT\u00b7AAG trinucleotides have been observed in full-penetrance repeats [Moseley et al 2006; Authors, unpublished data].' (GeneReviews)",
-        "details":null,
-        "width":46.0,
-        "OMIM":"608768",
-        "Prevalence":"0.5\/100000",
-        "Prevalence_details":"<1\/100,000; Tang et al., 2017; Expansion in 1:100-1200 chromosomes (GeneReview)",
-        "STRipy_gene":"ATXN8OS",
-        "gnomAD_gene":"ATXN8OS",
-        "GeneReviews":"NBK1268",
-        "Mondo":"0012116",
-        "Year":1999.0,
-        "MedGen":"332457",
-        "Orphanet":"98760",
-        "GARD":"4956",
-        "WebSTR_hg38":"5356762",
-        "WebSTR_hg19":"Expansion_SCA8\/ATXN8"
+        "mechanism":"Polyglutamine/toxic gain-of-function",
+        "mechanism_detail":"Polyglutamine/toxic gain-of-function (OMIM) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x"
+        ],
+        "details":"Two genes span the CTG/CAG repeat and are expressed in opposite directions: ATXN8, which encodes a nearly pure polyglutamine expansion protein in the CAG direction, and ATXN8OS (603680), which, when transcribed, produces a noncoding CUG expansion RNA (Moseley et al., 2006). Roda et al. suggested that the ATXN8 or ATXN8OS gene should not be evaluated in isolation as a candidate gene for spinocerebellar degenerative disease [pmid:28451643]. CCG/CGG interruptions in high-penetrance SCA8 families increased RAN translation and protein toxicity (PMID: 34632710); Interruptions in CTG/CAG expansion by 1 or more CCG/CGG, CTA/TAG, CTC/GAG, CCA/TGG, or CTT/AAG trinucleotides have been observed in full-penetrance repeats [Moseley et al 2006; Authors, unpublished data]. (GeneReviews)",
+        "omim":[
+            "608768"
+        ],
+        "prevalence":"0.5/100000",
+        "prevalence_details":"<1/100,000; Tang et al., 2017; Expansion in 1:100-1200 chromosomes (GeneReview). Found across ethnicities/ancestries, with population-dependent prevalence (NBK1268)",
+        "stripy":[
+            "ATXN8OS"
+        ],
+        "gnomad":[
+            "ATXN8OS"
+        ],
+        "genereviews":[
+            "NBK1268"
+        ],
+        "mondo":[
+            "0012116"
+        ],
+        "year":1999.0,
+        "medgen":[
+            "332457"
+        ],
+        "orphanet":[
+            "98760"
+        ],
+        "gard":[
+            "4956"
+        ],
+        "malacard":[
+            "SPN304"
+        ],
+        "webstr_hg38":[
+            "5356762"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA8/ATXN8"
+        ],
+        "tr_gnomad":[
+            "TR125263",
+            "TR125264"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 8 (SCA8) is a subtype of type I autosomal dominant cerebellar ataxia (ADCA type I) characterized by cerebellar ataxia and cognitive dysfunction in almost three quarters of patients and pyramidal and sensory signs in approximately a third of patients. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr16",
@@ -839,61 +1276,123 @@
         "stop_hg19":66524369,
         "start_t2t":72284667,
         "stop_t2t":72284761,
-        "notes_t2t":"(AATAA)19.4",
         "id":"SCA31_BEAN1",
         "disease_id":"SCA31",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"AATAA",
-        "pathogenic_motif_reference_orientation":"TGGAA,TAGAA",
-        "pathogenic_motif_gene_orientation":"AATGG,AATAG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"AAAAA,AAAAC,AAATG,AGAAA,ATAAG,TAAAC,TAACA,TACAA,TCAAA,TGCAA",
-        "unknown_motif_gene_orientation":"AAAAA,AAAAC,AAATG,AAAAG,AAGAT,AAACT,AACAT,AATAC,AAATC,AATGC",
+        "reference_motif_reference_orientation":[
+            "AATAA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TGGAA",
+            "TAGAA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AATGG",
+            "AATAG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "AAAAA",
+            "AAAAC",
+            "AAATG",
+            "AGAAA",
+            "ATAAG",
+            "TAAAC",
+            "TAACA",
+            "TACAA",
+            "TCAAA",
+            "TGCAA"
+        ],
+        "unknown_motif_gene_orientation":[
+            "AAAAA",
+            "AAAAC",
+            "AAATG",
+            "AAAAG",
+            "AAGAT",
+            "AAACT",
+            "AACAT",
+            "AATAC",
+            "AAATC",
+            "AATGC"
+        ],
         "disease":"Spinocerebellar Ataxia Type 31",
         "gene":"BEAN1",
         "flank_motif":null,
         "locus_structure":"(TGGAA)*(TAGAA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":"Intron 4\/4",
-        "normal":"0-10",
-        "normal_min":0.0,
-        "normal_max":10.0,
-        "intermediate":null,
+        "location_in_gene":"Intron 4/4",
+        "benign_min":0.0,
+        "benign_max":10.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">110",
         "pathogenic_min":110.0,
         "pathogenic_max":760.0,
         "ref_copies":14.4,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 56-62 (PMID: 36563608); Range: 8-83 (PMID: 23331413) ",
         "age_onset_min":8,
         "age_onset_max":83,
         "typ_age_onset_min":56.0,
         "typ_age_onset_max":62.0,
         "novel":"novel",
-        "Mechanism":"Epigenetic",
-        "Mechanism_detail":"Role in heterochromatin or chromosomal structure theorized ",
-        "Mechanism_source":"(OMIM)",
-        "source":"OMIM, Sato 2009, 19878914 (Pubmed), https:\/\/doi.org\/10.1038\/s41580-021-00382-6",
-        "notes":"Novel, STR-containing insertion, not present in reference genome: Reds disagree on normal\/pathogenic sizes",
-        "details":null,
-        "width":69.0,
-        "OMIM":"117210",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown (more common in Japanese pop)",
-        "STRipy_gene":"BEAN1",
-        "gnomAD_gene":"BEAN1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0007296",
-        "Year":2009.0,
-        "MedGen":"348439",
-        "Orphanet":"217012",
-        "GARD":"9975",
-        "WebSTR_hg38":"812447; 5971756",
-        "WebSTR_hg19":"STR_539736"
+        "mechanism":"Epigenetic",
+        "mechanism_detail":"Role in heterochromatin or chromosomal structure theorized (OMIM)",
+        "source":[
+            "OMIM",
+            "Sato 2009",
+            "19878914 (Pubmed)",
+            "https://doi.org/10.1038/s41580-021-00382-6"
+        ],
+        "details":"Novel, STR-containing insertion, not present in reference genome",
+        "omim":[
+            "117210"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Has been found in Japanese populations (OMIM: 117210)",
+        "stripy":[
+            "BEAN1"
+        ],
+        "gnomad":[
+            "BEAN1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0007296"
+        ],
+        "year":2009.0,
+        "medgen":[
+            "348439"
+        ],
+        "orphanet":[
+            "217012"
+        ],
+        "gard":[
+            "9975"
+        ],
+        "malacard":[
+            "SPN103"
+        ],
+        "webstr_hg38":[
+            "812447",
+            "5971756"
+        ],
+        "webstr_hg19":[
+            "STR_539736"
+        ],
+        "tr_gnomad":[
+            "TR141992"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 31 (SCA31) is a very rare subtype of autosomal dominant cerebellar ataxia type III (ADCA type III) characterized by the late-onset of cerebral ataxia, dysarthria and horizontal gaze nystagmus, and that is occasionally accompanied by pyramidal signs, tremor, decreased vibration sense and hearing difficulties. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr9",
@@ -903,61 +1402,97 @@
         "stop_hg19":27573544,
         "start_t2t":27584063,
         "stop_t2t":27584155,
-        "notes_t2t":"(GCCCCG)15.8",
         "id":"FTDALS1_C9orf72",
         "disease_id":"FTDALS1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GGCCCC",
-        "pathogenic_motif_reference_orientation":"GGCCCC",
-        "pathogenic_motif_gene_orientation":"CCGGGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
-        "disease":"Frontotemporal dementia (FTD) and\/or amyotrophic lateral sclerosis (ALS)",
+        "reference_motif_reference_orientation":[
+            "GGCCCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGCCCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCGGGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
+        "disease":"Frontotemporal dementia (FTD) and/or amyotrophic lateral sclerosis (ALS)",
         "gene":"C9orf72",
         "flank_motif":null,
         "locus_structure":"(GGCCCC)*",
-        "Inheritance":"AD",
-        "type":"Intronic",
+        "inheritance":[
+            "AD"
+        ],
+        "type":"5' UTR/Intronic",
         "location_in_gene":"Intron 1 or 5' depending on transcript",
-        "normal":"3\u201325 (2-19 Reds)",
-        "normal_min":2.0,
-        "normal_max":20.0,
-        "intermediate":"20-60",
+        "benign_min":2.0,
+        "benign_max":20.0,
         "intermediate_min":20.0,
         "intermediate_max":60.0,
-        "pathogenic":"250-2000",
         "pathogenic_min":250.0,
         "pathogenic_max":2000.0,
         "ref_copies":10.8,
-        "repeatunitlen":6,
+        "motif_len":6,
         "age_onset":"Typical: 50-64; Range: 20-91 (GeneReview)",
         "age_onset_min":20,
         "age_onset_max":91,
         "typ_age_onset_min":50.0,
         "typ_age_onset_max":64.0,
         "novel":"ref",
-        "Mechanism":"RNA toxicity proposed",
-        "Mechanism_detail":"\"The HRE forms DNA and RNA G-quadruplexes with distinct structures and promotes RNA\/DNA hybrids (R-loops). The structural polymorphism causes a repeat length-dependent accumulation of transcripts aborted in the HRE region.\"",
-        "Mechanism_source":"OMIM",
-        "source":"Hannan 2018, GeneReviews NBK535148, OMIM, s40478-021-01201-x",
-        "notes":"Pathogenic lower range is controversial. (STRipy)",
-        "details":"FTD and ALS form a clinical spectrum (PMID: 37388914)",
-        "width":62.0,
-        "OMIM":"105500",
-        "Prevalence":null,
-        "Prevalence_details":"The expansion of a hexanucleotide repeat GGGGCC in C9orf72 is the most common known cause of ALS accounting for ~ 40% familial cases and ~ 7% sporadic cases in the European population; overall ALS incidence is 1-2\/100,000 person-years, point prevalence is 3-5\/100,000 (Europe\/US); lifetime risk is 1 in 300 (PMID: 31315673). C9orf72-FTD is estimated to be 0.04-134:100,000 (GeneReview), and by our estimates 0.65-1.56\/100,000 for C9orf72-ALS. ",
-        "STRipy_gene":"C9ORF72",
-        "gnomAD_gene":"C9ORF72",
-        "GeneReviews":"NBK268647",
-        "Mondo":"0007105",
-        "Year":2011.0,
-        "MedGen":"1830423",
-        "Orphanet":"275872",
-        "GARD":"18396",
-        "WebSTR_hg38":"5877863; 1502453",
-        "WebSTR_hg19":"STR_1475506"
+        "mechanism":"RNA toxicity proposed",
+        "mechanism_detail":"The HRE forms DNA and RNA G-quadruplexes with distinct structures and promotes RNA/DNA hybrids (R-loops). The structural polymorphism causes a repeat length-dependent accumulation of transcripts aborted in the HRE region. (OMIM)",
+        "source":[
+            "Hannan 2018",
+            "GeneReviews NBK535148",
+            "OMIM",
+            "s40478-021-01201-x"
+        ],
+        "details":"FTD and ALS form a clinical spectrum (PMID: 37388914). Pathogenic lower range is controversial (STRipy).",
+        "omim":[
+            "105500"
+        ],
+        "prevalence":null,
+        "prevalence_details":"The expansion of a hexanucleotide repeat GGGGCC in C9orf72 is the most common known cause of ALS accounting for ~ 40% familial cases and ~ 7% sporadic cases in the European population; overall ALS incidence is 1-2/100,000 person-years, point prevalence is 3-5/100,000 (Europe/US); lifetime risk is 1 in 300 (PMID: 31315673). C9orf72-FTD is estimated to be 0.04-134:100,000 (GeneReview), and by our estimates 0.65-1.56/100,000 for C9orf72-ALS. The expansion has been found across ethnicities/ancestries, with population-dependent prevalence, highest in those with northern European ancestry (NBK268647)",
+        "stripy":[
+            "C9ORF72"
+        ],
+        "gnomad":[
+            "C9ORF72"
+        ],
+        "genereviews":[
+            "NBK268647"
+        ],
+        "mondo":[
+            "0007105"
+        ],
+        "year":2011.0,
+        "medgen":[
+            "1830423"
+        ],
+        "orphanet":[
+            "275872"
+        ],
+        "gard":[
+            "18396"
+        ],
+        "malacard":[
+            "FRN044"
+        ],
+        "webstr_hg38":[
+            "5877863",
+            "1502453"
+        ],
+        "webstr_hg19":[
+            "STR_1475506"
+        ],
+        "tr_gnomad":[
+            "TR92417"
+        ],
+        "disease_description":"Pure frontotemporal dementia, pure amyotrophic lateral sclerosis or combination of the two (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr19",
@@ -967,61 +1502,98 @@
         "stop_hg19":13318712,
         "start_t2t":13333137,
         "stop_t2t":13333176,
-        "notes_t2t":"(CTG)13.3",
         "id":"SCA6_CACNA1A",
         "disease_id":"SCA6",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CTG",
-        "pathogenic_motif_reference_orientation":"CTG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar Ataxia Type 6",
         "gene":"CACNA1A",
         "flank_motif":null,
         "locus_structure":"(CTG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Last Exon: 47 or 48",
-        "normal":"4\u201318",
-        "normal_min":4.0,
-        "normal_max":18.0,
-        "intermediate":"19",
+        "benign_min":4.0,
+        "benign_max":18.0,
         "intermediate_min":19.0,
         "intermediate_max":19.0,
-        "pathogenic":"20\u201333",
         "pathogenic_min":20.0,
         "pathogenic_max":33.0,
         "ref_copies":13.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 43-52 (GeneReview); Range: 16 (PMID: 23331413) - 73 (NBK1140)",
         "age_onset_min":16,
         "age_onset_max":73,
         "typ_age_onset_min":43.0,
         "typ_age_onset_max":52.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine ",
-        "Mechanism_detail":"Polyglutamine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148, s40478-021-01201-x",
-        "notes":null,
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148",
+            "s40478-021-01201-x"
+        ],
         "details":null,
-        "width":39.0,
-        "OMIM":"183086",
-        "Prevalence":"2.65\/100000",
-        "Prevalence_details":"13-15% of global SCA prevalence, estimated to be 0.02-31\/100,000 (GeneReview); Tang et al., 2017: 0.3-5\/100,000",
-        "STRipy_gene":"CACNA1A",
-        "gnomAD_gene":"CACNA1A",
-        "GeneReviews":"NBK1140",
-        "Mondo":"0008457",
-        "Year":1997.0,
-        "MedGen":"148458",
-        "Orphanet":"98758",
-        "GARD":"10351",
-        "WebSTR_hg38":"5624835",
-        "WebSTR_hg19":"Expansion_SCA6\/CACNA1A"
+        "omim":[
+            "183086"
+        ],
+        "prevalence":"2.65/100000",
+        "prevalence_details":"13-15% of global SCA prevalence, estimated to be 0.02-31/100,000 (GeneReview); Tang et al., 2017: 0.3-5/100,000. Found across ethnicities/ancestries, with population-dependent prevalence (NBK1140)",
+        "stripy":[
+            "CACNA1A"
+        ],
+        "gnomad":[
+            "CACNA1A"
+        ],
+        "genereviews":[
+            "NBK1140"
+        ],
+        "mondo":[
+            "0008457"
+        ],
+        "year":1997.0,
+        "medgen":[
+            "148458"
+        ],
+        "orphanet":[
+            "98758"
+        ],
+        "gard":[
+            "10351"
+        ],
+        "malacard":[
+            "SPN309"
+        ],
+        "webstr_hg38":[
+            "5624835"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA6/CACNA1A"
+        ],
+        "tr_gnomad":[
+            "TR154515"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 6 (SCA6) is the most common subtype of autosomal dominant cerebellar ataxia type III (ADCA type III) characterized by late-onset and slowly progressive gait ataxia and other cerebellar signs such as impaired muscle coordination and nystagmus. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr11",
@@ -1031,61 +1603,91 @@
         "stop_hg19":119077032,
         "start_t2t":119226663,
         "stop_t2t":119226696,
-        "notes_t2t":"(CGG)11.3",
         "id":"JBS_CBL",
         "disease_id":"JBS",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CGG",
-        "pathogenic_motif_reference_orientation":"CGG",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CGG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CGG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Jacobsen syndrome (FRAX11B fragile site)",
         "gene":"CBL",
         "flank_motif":null,
         "locus_structure":"(CGG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"<79",
-        "normal_min":11.0,
-        "normal_max":79.0,
-        "intermediate":null,
+        "benign_min":11.0,
+        "benign_max":79.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">100",
         "pathogenic_min":100.0,
         "pathogenic_max":100.0,
         "ref_copies":11.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Condition at birth.",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"DNA hypermethylation and 11q deletion",
-        "Mechanism_detail":"DNA hypermethylation\/11q deletion in sporadic cases",
-        "Mechanism_source":"PMID: 38467784",
-        "source":"https:\/\/doi.org\/10.1038\/s41580-021-00382-6, 7603564 (PubMed)",
-        "notes":null,
-        "details":null,
-        "width":33.0,
-        "OMIM":"147791",
-        "Prevalence":null,
-        "Prevalence_details":"1\/100,000 births; female\/male ratio 2:1 (PMID: 19267933); expansion can lead to deletion (shown in 2 cases) but total causality is unclear",
-        "STRipy_gene":"CBL",
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":"0007838",
-        "Year":null,
-        "MedGen":"162878",
-        "Orphanet":"2308",
-        "GARD":"307",
-        "WebSTR_hg38":"6166081; 430025",
-        "WebSTR_hg19":"STR_266122"
+        "mechanism":"DNA hypermethylation and 11q deletion",
+        "mechanism_detail":"DNA hypermethylation/11q deletion in sporadic cases [pmid:38467784]",
+        "source":[
+            "https://doi.org/10.1038/s41580-021-00382-6",
+            "7603564 (PubMed)"
+        ],
+        "details":"The CGG repeat expansion can lead to a fragile site and subsequent deletion 11q (shown in 2 cases) but total causality is unclear.",
+        "omim":[
+            "147791"
+        ],
+        "prevalence":null,
+        "prevalence_details":"1/100,000 births; female/male ratio 2:1 (PMID: 19267933). Found across ancestries/ethnicities (OMIM: 147791)",
+        "stripy":[
+            "CBL"
+        ],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[
+            "0007838"
+        ],
+        "year":null,
+        "medgen":[
+            "162878"
+        ],
+        "orphanet":[
+            "2308"
+        ],
+        "gard":[
+            "307"
+        ],
+        "malacard":[
+            "JCB001"
+        ],
+        "webstr_hg38":[
+            "6166081",
+            "430025"
+        ],
+        "webstr_hg19":[
+            "STR_266122"
+        ],
+        "tr_gnomad":[
+            "TR112816"
+        ],
+        "disease_description":"A multiple congenital anomaly/intellectual disability contiguous gene syndrome caused by partial deletion of the long arm of chromosome 11. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr3",
@@ -1095,61 +1697,96 @@
         "stop_hg19":128891502,
         "start_t2t":131917483,
         "stop_t2t":131917557,
-        "notes_t2t":"(CAGG)18.8",
         "id":"DM2_CNBP",
         "disease_id":"DM2",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CAGG",
-        "pathogenic_motif_reference_orientation":"CAGG",
-        "pathogenic_motif_gene_orientation":"CCTG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAGG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAGG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCTG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Myotonic Dystrophy Type 2",
         "gene":"CNBP",
         "flank_motif":"(CAGG)n(CAGA)10(CA)19",
         "locus_structure":"(CAGG)*(CAGA)*(CA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":null,
-        "normal":"11\u201326",
-        "normal_min":11.0,
-        "normal_max":26.0,
-        "intermediate":"27-74",
+        "location_in_gene":"Intron 1",
+        "benign_min":11.0,
+        "benign_max":26.0,
         "intermediate_min":27.0,
         "intermediate_max":74.0,
-        "pathogenic":"75-11,000",
         "pathogenic_min":75.0,
         "pathogenic_max":11000.0,
         "ref_copies":20.8,
-        "repeatunitlen":4,
+        "motif_len":4,
         "age_onset":"Typical: 28-56 (PMID: 29086017); Range: 0-73 (PMID: 31159885)",
         "age_onset_min":0,
         "age_onset_max":73,
         "typ_age_onset_min":28.0,
         "typ_age_onset_max":56.0,
         "novel":"ref",
-        "Mechanism":"Aberrant splicing",
-        "Mechanism_detail":"Aberrant splicing",
-        "Mechanism_source":"(doi.org\/10.1093\/hmg\/ddr568)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK1466, https:\/\/doi.org\/10.1038\/s41580-021-00382-6",
-        "notes":"(TG)n(TCTG)n(CCTG)n. CCTG expansion causes DM2 but the other repeat units are also variable. Interruptions include GCTG\/TCTG\/GGCT (PMID: 35245110)",
-        "details":"Penetrance is age-dependent and approaches 100%",
-        "width":82.0,
-        "OMIM":"602668",
-        "Prevalence":"2.29\/100000",
-        "Prevalence_details":"2.29\/100,000 (PMID: 35483324); population specific prevalence (GeneReview)",
-        "STRipy_gene":"CNBP",
-        "gnomAD_gene":"CNBP",
-        "GeneReviews":"NBK1466",
-        "Mondo":"0011266",
-        "Year":2001.0,
-        "MedGen":"419137",
-        "Orphanet":"606",
-        "GARD":"9728",
-        "WebSTR_hg38":"741073",
-        "WebSTR_hg19":null
+        "mechanism":"Aberrant splicing",
+        "mechanism_detail":"Aberrant splicing (doi.org/10.1093/hmg/ddr568)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK1466",
+            "https://doi.org/10.1038/s41580-021-00382-6"
+        ],
+        "details":"Penetrance is age-dependent and approaches 100%. Locus structure is (TG)n(TCTG)n(CCTG)n. CCTG expansion causes DM2 but the other repeat units are also variable. Interruptions include GCTG/TCTG/GGCT (PMID: 35245110)",
+        "omim":[
+            "602668"
+        ],
+        "prevalence":"2.29/100000",
+        "prevalence_details":"2.29/100,000 (PMID: 35483324); population specific prevalence (GeneReview). Most cases have European ancestry, but has been reported worldwide (NBK1466)",
+        "stripy":[
+            "CNBP"
+        ],
+        "gnomad":[
+            "CNBP"
+        ],
+        "genereviews":[
+            "NBK1466"
+        ],
+        "mondo":[
+            "0011266"
+        ],
+        "year":2001.0,
+        "medgen":[
+            "419137"
+        ],
+        "orphanet":[
+            "606"
+        ],
+        "gard":[
+            "9728"
+        ],
+        "malacard":[
+            "MYT020"
+        ],
+        "webstr_hg38":[
+            "741073"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR35563",
+            "TR35564",
+            "TR35565"
+        ],
+        "disease_description":"Myotonic dystrophy type 2 (MD2), also known as proximal myotonic myopathy, is a very rare genetic multi-system disorder of late childhood or adult-onset characterized by mild myotonia, muscle weakness, and rarely cardiac conduction disorders. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr19",
@@ -1159,61 +1796,100 @@
         "stop_hg19":18896859,
         "start_t2t":18921630,
         "stop_t2t":18921645,
-        "notes_t2t":null,
         "id":"EDM1-PSACH_COMP",
         "disease_id":"EDM1, PSACH",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GTC",
-        "pathogenic_motif_reference_orientation":"GTC",
-        "pathogenic_motif_gene_orientation":"ACG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GTC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GTC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ACG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Multiple epiphyseal dysplasia, Pseudoachondroplasia",
         "gene":"COMP",
         "flank_motif":null,
         "locus_structure":"(GTC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
-        "location_in_gene":null,
-        "normal":"5",
-        "normal_min":5.0,
-        "normal_max":5.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 13",
+        "benign_min":5.0,
+        "benign_max":5.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"4 or 6-7",
         "pathogenic_min":6.0,
         "pathogenic_max":7.0,
         "ref_copies":5.0,
-        "repeatunitlen":3,
-        "age_onset":"Typical: 0-2 (COMP-PSACH)\/ 1-12 (EDM1); Range: 0 (PSACH) - 13 (EDM1); 3-13 specific to trinucleotide expansions (duplications), several contractions but unknown exact AoO",
+        "motif_len":3,
+        "age_onset":"Typical: 0-2 (COMP-PSACH)/ 1-12 (EDM1); Range: 0 (PSACH) - 13 (EDM1); 3-13 specific to trinucleotide expansions (duplications), several contractions but unknown exact AoO",
         "age_onset_min":3,
         "age_onset_max":13,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Protein LOF",
-        "Mechanism_detail":"LOF, domain dependent",
-        "Mechanism_source":"(https:\/\/pubmed.ncbi.nlm.nih.gov\/29530484\/)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2",
-        "notes":"Two diseases, same locus. Both expansions and contractions associated with disease",
-        "details":null,
-        "width":15.0,
-        "OMIM":"132400; 177170",
-        "Prevalence":null,
-        "Prevalence_details":"Specific contribution of COMP repeats to EDM1 is unknown (~300 COMP mutation variants for both phenotypes); likely 1:90,000 prevalence for COMP-PSACH that is repeat-specific.",
-        "STRipy_gene":"COMP",
-        "gnomAD_gene":"COMP",
-        "GeneReviews":"NBK1123; NBK1487",
-        "Mondo":"0008322; 0007561",
-        "Year":null,
-        "MedGen":"98378; 325376",
-        "Orphanet":"750; 93308",
-        "GARD":"4540; 2180",
-        "WebSTR_hg38":"1317658",
-        "WebSTR_hg19":"STR_673389"
+        "mechanism":"Protein LOF",
+        "mechanism_detail":"LOF, domain dependent (https://pubmed.ncbi.nlm.nih.gov/29530484/)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2"
+        ],
+        "details":"Both expansions to (GTC)6-7 and contractions to (GTC)4 are associated with disease",
+        "omim":[
+            "132400",
+            "177170"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Specific contribution of COMP repeats to EDM1 is unknown (~300 COMP mutation variants for both phenotypes); likely 1:90,000 prevalence for COMP-PSACH that is repeat-specific. Found across ancestries/ethnicities (NBK1123, NBK1487)",
+        "stripy":[
+            "COMP"
+        ],
+        "gnomad":[
+            "COMP"
+        ],
+        "genereviews":[
+            "NBK1123",
+            "NBK1487"
+        ],
+        "mondo":[
+            "0008322",
+            "0007561"
+        ],
+        "year":null,
+        "medgen":[
+            "98378",
+            "325376"
+        ],
+        "orphanet":[
+            "750",
+            "93308"
+        ],
+        "gard":[
+            "4540",
+            "2180"
+        ],
+        "malacard":[
+            "EPP017",
+            "PSD012"
+        ],
+        "webstr_hg38":[
+            "1317658"
+        ],
+        "webstr_hg19":[
+            "STR_673389"
+        ],
+        "tr_gnomad":[
+            "TR155017"
+        ],
+        "disease_description":"Pseudoachondroplasia is characterized by severe growth deficiency and deformations such as bow legs and hyperlordosis.; Multiple epiphyseal dysplasia type 1 (MED 1) is a form of multiple epiphyseal dysplasia that is characterized by normal or mild short stature, pain in the hips and/or knees, progressive deformity of extremities and early-onset osteoarthrosis. Specific features to MED 1 include a more pronounced involvement of hip joints and gait abnormality and a shorter adult height. MED1 is allelic to pseudoachondroplasia with which it shares clinical and radiological features. The disease follows an autosomal dominant mode of transmission. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr21",
@@ -1223,61 +1899,95 @@
         "stop_hg19":45196360,
         "start_t2t":42132055,
         "stop_t2t":42132091,
-        "notes_t2t":null,
         "id":"EPM1_CSTB",
         "disease_id":"EPM1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CGCGGGGCGGGG",
-        "pathogenic_motif_reference_orientation":"CGCGGGGCGGGG",
-        "pathogenic_motif_gene_orientation":"CCCCGCCCCGCG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CGCGGGGCGGGG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CGCGGGGCGGGG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCCCGCCCCGCG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Progressive Myoclonic Epilepsy Type 1 (EPM1) Unverricht-Lundborg Disease (ULD)",
         "gene":"CSTB",
         "flank_motif":null,
         "locus_structure":"(CGCGGGGCGGGG)*",
-        "Inheritance":"AR",
-        "type":"Promoter",
+        "inheritance":[
+            "AR"
+        ],
+        "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"2-3",
-        "normal_min":2.0,
-        "normal_max":3.0,
-        "intermediate":"12-17",
+        "benign_min":2.0,
+        "benign_max":3.0,
         "intermediate_min":12.0,
         "intermediate_max":17.0,
-        "pathogenic":">=30",
         "pathogenic_min":30.0,
         "pathogenic_max":81.0,
         "ref_copies":null,
-        "repeatunitlen":12,
+        "motif_len":12,
         "age_onset":"Typical: 6-15  (GeneReview); Range: 6-16 (PMID: 9012407)",
         "age_onset_min":6,
         "age_onset_max":16,
         "typ_age_onset_min":6.0,
         "typ_age_onset_max":15.0,
         "novel":null,
-        "Mechanism":"LOF",
-        "Mechanism_detail":"LoF",
-        "Mechanism_source":"PMID: 38467784",
-        "source":"OMIM, https:\/\/www.ncbi.nlm.nih.gov\/books\/NBK1142\/, PMID: 9126745",
-        "notes":null,
+        "mechanism":"LOF",
+        "mechanism_detail":"LoF [pmid:38467784]",
+        "source":[
+            "OMIM",
+            "https://www.ncbi.nlm.nih.gov/books/NBK1142/",
+            "PMID: 9126745"
+        ],
         "details":null,
-        "width":null,
-        "OMIM":"254800",
-        "Prevalence":null,
-        "Prevalence_details":"Worldwide prevalence unknown; Finland prevalence 2-4\/100,000",
-        "STRipy_gene":null,
-        "gnomAD_gene":"CSTB",
-        "GeneReviews":"NBK1142",
-        "Mondo":"0009698",
-        "Year":1997.0,
-        "MedGen":"155923",
-        "Orphanet":"308",
-        "GARD":"3876",
-        "WebSTR_hg38":"5547429",
-        "WebSTR_hg19":"STR_886261"
+        "omim":[
+            "254800"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Worldwide prevalence unknown; Finland prevalence 2-4/100,000. Found across ethnicities/ancestries, with population-dependent prevalence; highest in Tunisia, Algeria, Morocco, and Finland (NBK1142)",
+        "stripy":[],
+        "gnomad":[
+            "CSTB"
+        ],
+        "genereviews":[
+            "NBK1142"
+        ],
+        "mondo":[
+            "0009698"
+        ],
+        "year":1997.0,
+        "medgen":[
+            "155923"
+        ],
+        "orphanet":[
+            "308"
+        ],
+        "gard":[
+            "3876"
+        ],
+        "malacard":[
+            "MYC080"
+        ],
+        "webstr_hg38":[
+            "5547429"
+        ],
+        "webstr_hg19":[
+            "STR_886261"
+        ],
+        "tr_gnomad":[
+            "TR163552"
+        ],
+        "disease_description":"Unverricht-Lundborg disease (ULD) is a rare progressive myoclonic epilepsy disorder characterized by action- and stimulus-sensitive myoclonus, and tonic-clonic seizures with ataxia, but with only a mild cognitive decline over time. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr1",
@@ -1287,61 +1997,101 @@
         "stop_hg19":57832797,
         "start_t2t":57245936,
         "stop_t2t":57245977,
-        "notes_t2t":"(AAAAT)8.6",
         "id":"SCA37_DAB1",
         "disease_id":"SCA37",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"AAAAT",
-        "pathogenic_motif_reference_orientation":"GAAAT",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"AAAAA",
-        "unknown_motif_gene_orientation":"TTTTT",
+        "reference_motif_reference_orientation":[
+            "AAAAT"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GAAAT"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "AAAAA"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT"
+        ],
         "disease":"Spinocerebellar Ataxia Type 37",
         "gene":"DAB1",
         "flank_motif":null,
         "locus_structure":"(AAAAT)*(GAAAT)*(AAAAT)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 1 (most isoforms)",
-        "normal":"0-30",
-        "normal_min":0.0,
-        "normal_max":30.0,
-        "intermediate":null,
+        "benign_min":0.0,
+        "benign_max":30.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"31-75",
         "pathogenic_min":31.0,
         "pathogenic_max":75.0,
         "ref_copies":0.0,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 33-53; Range: 18-64 (GeneReview)",
         "age_onset_min":18,
         "age_onset_max":64,
         "typ_age_onset_min":33.0,
         "typ_age_onset_max":53.0,
         "novel":"novel",
-        "Mechanism":"Protein toxic GOF",
-        "Mechanism_detail":"toxic gain-of-function mechanism",
-        "Mechanism_source":"(OMIM)",
-        "source":"Seixas et al 2017 AJHG, NBK541729, s40478-021-01201-x",
-        "notes":"Novel. Normal: [(ATTTT)7\u2013400] Pathogenic: [(ATTTT)60\u201379(ATTTC)31\u201375(ATTTT)58\u201390], ATTTC within (ATTTT)7\u2013400 repeat region",
+        "mechanism":"Protein toxic GOF",
+        "mechanism_detail":"toxic gain-of-function mechanism (OMIM)",
+        "source":[
+            "Seixas et al 2017 AJHG",
+            "NBK541729",
+            "s40478-021-01201-x"
+        ],
         "details":"Pathogenicity only associated with pathogenic motif >30 repeats, flanked by at least 58 repeats of reference motif on either side; reference repeat (AAAAT) can range from 1 to 400 repeats, although typically less than 30 (NBK541729). The pathogenic motif is unstable, particularly when transmitted by the father (NBK541729).",
-        "width":81.0,
-        "OMIM":"615945",
-        "Prevalence":null,
-        "Prevalence_details":"0.20\/100,000 specific to Portugal; not yet found in other geographic regions",
-        "STRipy_gene":"DAB1",
-        "gnomAD_gene":"DAB1",
-        "GeneReviews":"NBK541729",
-        "Mondo":"0014410",
-        "Year":2017.0,
-        "MedGen":"855217",
-        "Orphanet":"363710",
-        "GARD":"12368",
-        "WebSTR_hg38":"1144531",
-        "WebSTR_hg19":"STR_39393"
+        "omim":[
+            "615945"
+        ],
+        "prevalence":null,
+        "prevalence_details":"0.20/100,000 specific to Portugal; not yet found in other geographic regions. Founder effect from Iberian Peninsula (NBK541729)",
+        "stripy":[
+            "DAB1"
+        ],
+        "gnomad":[
+            "DAB1"
+        ],
+        "genereviews":[
+            "NBK541729"
+        ],
+        "mondo":[
+            "0014410"
+        ],
+        "year":2017.0,
+        "medgen":[
+            "855217"
+        ],
+        "orphanet":[
+            "363710"
+        ],
+        "gard":[
+            "12368"
+        ],
+        "malacard":[
+            "SPN283"
+        ],
+        "webstr_hg38":[
+            "1144531"
+        ],
+        "webstr_hg19":[
+            "STR_39393"
+        ],
+        "tr_gnomad":[
+            "TR3445"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 37 (SCA37) is a subtype of autosomal dominant cerebellar ataxia type 1 (ADCA type 1), characterized by a cerebellar syndrome along with altered vertical eye movements. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr12",
@@ -1351,61 +2101,91 @@
         "stop_hg19":50898805,
         "start_t2t":50468096,
         "stop_t2t":50468116,
-        "notes_t2t":null,
         "id":"FRA12A_DIP2B",
         "disease_id":"FRA12A",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GGC",
-        "pathogenic_motif_reference_orientation":"GGC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Intellectual developmental disorder, FRA12A type",
         "gene":"DIP2B",
         "flank_motif":null,
         "locus_structure":"(GGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"6-23",
-        "normal_min":6.0,
-        "normal_max":23.0,
-        "intermediate":"~139-206",
+        "benign_min":6.0,
+        "benign_max":23.0,
         "intermediate_min":139.0,
         "intermediate_max":206.0,
-        "pathogenic":"~273-306",
         "pathogenic_min":273.0,
         "pathogenic_max":306.0,
         "ref_copies":7.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 0-1 (PMID: 3742859) (small sample size); Range: 0-3 (PMID: 4042396)",
         "age_onset_min":0,
         "age_onset_max":3,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Increased gene expression, methylation",
-        "Mechanism_detail":"Increased gene expression, methylation",
-        "Mechanism_source":"(OMIM, https:\/\/www.medrxiv.org\/content\/10.1101\/2022.09.12.22279739v3.full-text)",
-        "source":"OMIM, NBK535148, https:\/\/www.medrxiv.org\/content\/10.1101\/2022.09.12.22279739v3.full-text",
-        "notes":null,
+        "mechanism":"Increased gene expression, methylation",
+        "mechanism_detail":"Increased gene expression, methylation (OMIM, https://www.medrxiv.org/content/10.1101/2022.09.12.22279739v3.full-text)",
+        "source":[
+            "OMIM",
+            "NBK535148",
+            "https://www.medrxiv.org/content/10.1101/2022.09.12.22279739v3.full-text"
+        ],
         "details":null,
-        "width":20.0,
-        "OMIM":"136630",
-        "Prevalence":null,
-        "Prevalence_details":null,
-        "STRipy_gene":"DIP2B",
-        "gnomAD_gene":"DIP2B",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0007634",
-        "Year":null,
-        "MedGen":"369613",
-        "Orphanet":null,
-        "GARD":null,
-        "WebSTR_hg38":"5075695",
-        "WebSTR_hg19":"Expansion_FRA12A_MR\/DIP2B"
+        "omim":[
+            "136630"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Appears to occur in those of European ancestry/ethnicity (OMIM: 136630)",
+        "stripy":[
+            "DIP2B"
+        ],
+        "gnomad":[
+            "DIP2B"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0007634"
+        ],
+        "year":null,
+        "medgen":[
+            "369613"
+        ],
+        "orphanet":[],
+        "gard":[],
+        "malacard":[
+            "INT482"
+        ],
+        "webstr_hg38":[
+            "5075695"
+        ],
+        "webstr_hg19":[
+            "Expansion_FRA12A_MR/DIP2B"
+        ],
+        "tr_gnomad":[
+            "TR116656"
+        ],
+        "disease_description":"...impaired intellectual development with or without other anomalies has been described in patients with over 40% of cells expressing FRA12A (OMIM:136630).",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -1415,61 +2195,91 @@
         "stop_hg19":31302722,
         "start_t2t":30882695,
         "stop_t2t":30882743,
-        "notes_t2t":"(TTC)22.7",
         "id":"DMD_DMD",
         "disease_id":"DMD",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"TTC",
-        "pathogenic_motif_reference_orientation":"TTC",
-        "pathogenic_motif_gene_orientation":"AAG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "TTC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TTC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AAG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Duchenne muscular dystrophy",
         "gene":"DMD",
         "flank_motif":null,
         "locus_structure":"(TTC)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"Intronic",
-        "location_in_gene":null,
-        "normal":"<33",
-        "normal_min":16.0,
-        "normal_max":33.0,
-        "intermediate":null,
+        "location_in_gene":"Intron 62",
+        "benign_min":16.0,
+        "benign_max":33.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">59",
         "pathogenic_min":59.0,
         "pathogenic_max":82.0,
         "ref_copies":16.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 6-7 (usual disease is 0-3)",
         "age_onset_min":6,
         "age_onset_max":7,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Protein LOF",
-        "Mechanism_detail":"Functional defect in dystrophin\/dystroglycan",
-        "Mechanism_source":"(https:\/\/doi.org\/10.1007\/s10038-006-0056-7)",
-        "source":"PMID: 27417533",
-        "notes":null,
+        "mechanism":"Protein LOF",
+        "mechanism_detail":"Functional defect in dystrophin/dystroglycan (https://doi.org/10.1007/s10038-006-0056-7)",
+        "source":[
+            "PMID: 27417533"
+        ],
         "details":"There is conflicting evidence for the association between this repeat expansion and Duchenne muscular dystrophy. The association was reported in a single family (PMID: 27417533). The population frequency of the proposed pathogenic allele is much higher than expected for a highly penetrant early-onset condition.",
-        "width":48.0,
-        "OMIM":"310200",
-        "Prevalence":"4.8\/100000",
-        "Prevalence_details":"Believed to be 0 for disease specific to STR expansion. 1\/3500-4700 male births (incidence) for overall DMD (one of the most common and severe congenital myopathies). 4.8\/100,000 prevalence PMID: 35168641",
-        "STRipy_gene":"DMD",
-        "gnomAD_gene":"DMD",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010679",
-        "Year":null,
-        "MedGen":"3925",
-        "Orphanet":"98896",
-        "GARD":"6291",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":"STR_1545664"
+        "omim":[
+            "310200"
+        ],
+        "prevalence":"4.8/100000",
+        "prevalence_details":"Believed to be 0 for disease specific to STR expansion. 1/3500-4700 male births (incidence) for overall DMD (one of the most common and severe congenital myopathies). 4.8/100,000 prevalence PMID: 35168641. DMD repeat locus expansion only identified in one Greek family (PMID: 27417533)",
+        "stripy":[
+            "DMD"
+        ],
+        "gnomad":[
+            "DMD"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010679"
+        ],
+        "year":null,
+        "medgen":[
+            "3925"
+        ],
+        "orphanet":[
+            "98896"
+        ],
+        "gard":[
+            "6291"
+        ],
+        "malacard":[
+            "MSC157"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[
+            "STR_1545664"
+        ],
+        "tr_gnomad":[
+            "TR167703"
+        ],
+        "disease_description":"Duchenne muscular dystrophy (DMD) is a neuromuscular disease characterized by rapidly progressive muscle weakness and wasting due to degeneration of skeletal, smooth and cardiac muscle. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr19",
@@ -1479,61 +2289,96 @@
         "stop_hg19":46273524,
         "start_t2t":48597739,
         "stop_t2t":48597756,
-        "notes_t2t":null,
         "id":"DM1_DMPK",
         "disease_id":"DM1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CAG",
-        "pathogenic_motif_reference_orientation":"CAG",
-        "pathogenic_motif_gene_orientation":"CTG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CTG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Myotonic Dystrophy Type 1",
         "gene":"DMPK",
         "flank_motif":null,
         "locus_structure":"(CAG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"3' UTR",
-        "location_in_gene":"Last exon",
-        "normal":"5\u201334",
-        "normal_min":5.0,
-        "normal_max":34.0,
-        "intermediate":"35-49",
+        "location_in_gene":null,
+        "benign_min":5.0,
+        "benign_max":34.0,
         "intermediate_min":35.0,
         "intermediate_max":49.0,
-        "pathogenic":"50-1000",
         "pathogenic_min":50.0,
         "pathogenic_max":1000.0,
         "ref_copies":20.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 10-30 (\"classic\", GeneReview); Range: 0-74 (PMID: 38454488)",
         "age_onset_min":0,
         "age_onset_max":74,
         "typ_age_onset_min":10.0,
         "typ_age_onset_max":30.0,
         "novel":"ref",
-        "Mechanism":"RNA GOF",
-        "Mechanism_detail":"RNA gain-of-function - RNA gelation leading to misregulation of alternative splicing",
-        "Mechanism_source":"(doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK1165, s40478-021-01201-x",
-        "notes":"'3%-8% of DM1 expansions contain variant repeats such as CCG and CGG. These are referred to as variant repeat interruptions and may be associated with later onset and milder phenotype [Miller et al 2020].'(GeneReviews) 'Interruptions of the CTG repeat with CCG, GGC, CTC or CAG motifs are estimated to occur in 3\u201311% of DM1 patients' (PMID: 35741732)",
-        "details":null,
-        "width":62.0,
-        "OMIM":"160900",
-        "Prevalence":"9.27\/100000",
-        "Prevalence_details":"5-20\/100,000 (GeneReview); Tang et al., 2017: 0.5-18.1\/100,000; 6.5\/100,000 (PMID: 31159885) ; 9.27 cases (95% CI: 4.73-15.21) per 100,000, ranging from 0.37 to 36.29 cases per 100,000 (PMID: 35483324)",
-        "STRipy_gene":"DMPK",
-        "gnomAD_gene":"DMPK",
-        "GeneReviews":"NBK1165",
-        "Mondo":"0008056",
-        "Year":1992.0,
-        "MedGen":"886881",
-        "Orphanet":"273",
-        "GARD":"8310",
-        "WebSTR_hg38":"5650727",
-        "WebSTR_hg19":"Expansion_DM1\/DMPK"
+        "mechanism":"RNA GOF",
+        "mechanism_detail":"RNA gain-of-function - RNA gelation leading to misregulation of alternative splicing (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK1165",
+            "s40478-021-01201-x"
+        ],
+        "details":"'3%-8% of DM1 expansions contain variant repeats such as CCG and CGG. These are referred to as variant repeat interruptions and may be associated with later onset and milder phenotype [Miller et al 2020].'(GeneReviews) 'Interruptions of the CTG repeat with CCG, GGC, CTC or CAG motifs are estimated to occur in 3-11% of DM1 patients' (PMID: 35741732)",
+        "omim":[
+            "160900"
+        ],
+        "prevalence":"9.27/100000",
+        "prevalence_details":"5-20/100,000 (GeneReview); Tang et al., 2017: 0.5-18.1/100,000; 6.5/100,000 (PMID: 31159885) ; 9.27 cases (95% CI: 4.73-15.21) per 100,000, ranging from 0.37 to 36.29 cases per 100,000 (PMID: 35483324). Found across ethnicities/ancestries, with population-dependent prevalence (NBK1165)",
+        "stripy":[
+            "DMPK"
+        ],
+        "gnomad":[
+            "DMPK"
+        ],
+        "genereviews":[
+            "NBK1165"
+        ],
+        "mondo":[
+            "0008056"
+        ],
+        "year":1992.0,
+        "medgen":[
+            "886881"
+        ],
+        "orphanet":[
+            "273"
+        ],
+        "gard":[
+            "8310"
+        ],
+        "malacard":[
+            "MYT021"
+        ],
+        "webstr_hg38":[
+            "5650727"
+        ],
+        "webstr_hg19":[
+            "Expansion_DM1/DMPK"
+        ],
+        "tr_gnomad":[
+            "TR156684"
+        ],
+        "disease_description":"Steinert disease, also known as myotonic dystrophy type 1, is a muscle disease characterized by myotonia and by multiorgan damage that combines various degrees of muscle weakness, arrhythmia and/or cardiac conduction disorders, cataract, endocrine damage, sleep disorders and baldness. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr17",
@@ -1543,61 +2388,87 @@
         "stop_hg19":78120938,
         "start_t2t":81047454,
         "stop_t2t":81047534,
-        "notes_t2t":null,
         "id":"RCPS_EIF4A3",
         "disease_id":"RCPS",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CCTCGCTGTGCCGCTGCCGA",
-        "pathogenic_motif_reference_orientation":"CCTCGCTGTGCCGCTGCCGA",
-        "pathogenic_motif_gene_orientation":"ACAGCGAGGTCGGCAGCGGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CCTCGCTGTGCCGCTGCCGA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CCTCGCTGTGCCGCTGCCGA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ACAGCGAGGTCGGCAGCGGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Richieri-Costa-Pereira syndrome",
         "gene":"EIF4A3",
         "flank_motif":null,
         "locus_structure":"(CCTCGCTGCGCCGCTGCCGA)*(CCTCGCTGTGCCGCTGCCGA)*",
-        "Inheritance":"AR",
+        "inheritance":[
+            "AR"
+        ],
         "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"1-9",
-        "normal_min":1.0,
-        "normal_max":9.0,
-        "intermediate":"10-13",
+        "benign_min":1.0,
+        "benign_max":9.0,
         "intermediate_min":10.0,
         "intermediate_max":13.0,
-        "pathogenic":">14",
         "pathogenic_min":14.0,
         "pathogenic_max":16.0,
         "ref_copies":null,
-        "repeatunitlen":20,
+        "motif_len":20,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":0.0,
         "typ_age_onset_max":0.0,
         "novel":null,
-        "Mechanism":"LoF",
-        "Mechanism_detail":"LoF",
-        "Mechanism_source":"PMID: 38467784",
-        "source":"https:\/\/www.ncbi.nlm.nih.gov\/books\/NBK535148\/",
-        "notes":null,
+        "mechanism":"LoF",
+        "mechanism_detail":"LoF [pmid:38467784]",
+        "source":[
+            "https://www.ncbi.nlm.nih.gov/books/NBK535148/"
+        ],
         "details":"Complex repeat (GeneReview).",
-        "width":null,
-        "OMIM":"268305",
-        "Prevalence":null,
-        "Prevalence_details":"49 cases as of Nov 2023 (doi.org\/10.1016\/j.omsc.2023.100340)",
-        "STRipy_gene":null,
-        "gnomAD_gene":"EIF4A3",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0009998",
-        "Year":null,
-        "MedGen":"336581",
-        "Orphanet":"3102",
-        "GARD":"4718",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":null
+        "omim":[
+            "268305"
+        ],
+        "prevalence":null,
+        "prevalence_details":"49 cases as of Nov 2023 (doi.org/10.1016/j.omsc.2023.100340). Found in Brazilian families and one unrelated French patient (MONDO:0009998)",
+        "stripy":[],
+        "gnomad":[
+            "EIF4A3"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0009998"
+        ],
+        "year":null,
+        "medgen":[
+            "336581"
+        ],
+        "orphanet":[
+            "3102"
+        ],
+        "gard":[
+            "4718"
+        ],
+        "malacard":[
+            "RBN014"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR148462"
+        ],
+        "disease_description":"Richieri Costa-Pereira syndrome is characterized by short stature, Robin sequence, cleft mandible, pre/postaxial hand anomalies (including hypoplastic thumbs), and clubfoot. It has been described in 14 Brazilian families and in one unrelated French patient. Prominent low set ears and a highly arched palate were also observed. Transmission is autosomal recessive. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr13",
@@ -1607,61 +2478,97 @@
         "stop_hg19":102814076,
         "start_t2t":101377640,
         "stop_t2t":101377789,
-        "notes_t2t":null,
         "id":"SCA27B_FGF14",
         "disease_id":"SCA27B",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GAA",
-        "pathogenic_motif_reference_orientation":"GAA",
-        "pathogenic_motif_gene_orientation":"CTT",
-        "benign_motif_reference_orientation":"GAAGGA, GAAGAAGAAGAAGCA",
-        "benign_motif_gene_orientation":"CCTTCT,CTGCTTCTTCTTCTT",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GAA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GAA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CTT"
+        ],
+        "benign_motif_reference_orientation":[
+            "GAAGGA",
+            "GAAGAAGAAGAAGCA"
+        ],
+        "benign_motif_gene_orientation":[
+            "CCTTCT",
+            "CTGCTTCTTCTTCTT"
+        ],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar ataxia 27B",
         "gene":"FGF14",
         "flank_motif":null,
         "locus_structure":"(GAA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 1",
-        "normal":"8-179",
-        "normal_min":8.0,
-        "normal_max":179.0,
-        "intermediate":"180-319",
+        "benign_min":8.0,
+        "benign_max":179.0,
         "intermediate_min":180.0,
         "intermediate_max":319.0,
-        "pathogenic":">319",
         "pathogenic_min":320.0,
         "pathogenic_max":937.0,
         "ref_copies":50.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 42-70; Range: 21-87 (NBK599589); similar range found in PMID: 39263992",
         "age_onset_min":21,
         "age_onset_max":87,
         "typ_age_onset_min":42.0,
         "typ_age_onset_max":70.0,
         "novel":"ref",
-        "Mechanism":"Haploinsufficiency",
-        "Mechanism_detail":"Reduced transcript 2",
-        "Mechanism_source":"PMCID: PMC10042577",
-        "source":"https:\/\/www.omim.org\/entry\/620174, https:\/\/www.cell.com\/ajhg\/fulltext\/S0002-9297(22)00506-7, PMCID: PMC10042577, PMID: 37399286, PMID: 39227614",
-        "notes":"Flanking regions appear to correlate with repeat size (PMID: 39227614, PMID: 38937606).",
-        "details":"Higher repeat size is associated with earlier age of onset (PMID: 39263992). The 250-300 repeats range is linked to incomplete penetrance and >300 repeats with complete penetrance in some studies and resources (NBK599589; PMID: 37399286; PMID: 39227614). However, our thresholds are taken from suggestions made by Mohren et al upon evaluation of 169 cases and 802 controls; the authors propose lower thresholds based on pathogenic cases of shorter pure repeats (PMID: 39227614). Additionally, this study suggests that benign motifs may disrupt the formation of secondary structures in DNA\/RNA, leading to reduced pathogenicity.",
-        "width":null,
-        "OMIM":"620174",
-        "Prevalence":null,
-        "Prevalence_details":"Intermediate expansions 1-2% of population, but non-GAA-pure without relation to ataxia. (GeneReview)",
-        "STRipy_gene":"FGF14",
-        "gnomAD_gene":null,
-        "GeneReviews":"NBK599589",
-        "Mondo":"0859340",
-        "Year":2023.0,
-        "MedGen":"1824051",
-        "Orphanet":"675216",
-        "GARD":null,
-        "WebSTR_hg38":"1272528",
-        "WebSTR_hg19":null
+        "mechanism":"Haploinsufficiency",
+        "mechanism_detail":"Reduced transcript 2 [pmcid:PMC10042577]",
+        "source":[
+            "https://www.omim.org/entry/620174",
+            "https://www.cell.com/ajhg/fulltext/S0002-9297(22)00506-7",
+            "PMCID: PMC10042577",
+            "PMID: 37399286",
+            "PMID: 39227614"
+        ],
+        "details":"Higher repeat size is associated with earlier age of onset (PMID: 39263992). The 250-300 repeats range is linked to incomplete penetrance and >300 repeats with complete penetrance in some studies and resources (NBK599589; PMID: 37399286; PMID: 39227614). However, our thresholds are taken from suggestions made by Mohren et al upon evaluation of 169 cases and 802 controls; the authors propose lower thresholds based on pathogenic cases of shorter pure repeats (PMID: 39227614). Additionally, this study suggests that benign motifs may disrupt the formation of secondary structures in DNA/RNA, leading to reduced pathogenicity. Variantion in flanking regions appear to correlate with repeat size (PMID: 39227614, PMID: 38937606).",
+        "omim":[
+            "620174"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Intermediate expansions 1-2% of population, but non-GAA-pure without relation to ataxia. (GeneReview). Found in multiple ethnicities (PMID: 38876750); diagnosed patients in America, Brazil, Japan, Germany, Spain, Canada, France, Austria and Australia (NBK599589)",
+        "stripy":[
+            "FGF14"
+        ],
+        "gnomad":[],
+        "genereviews":[
+            "NBK599589"
+        ],
+        "mondo":[
+            "0859340"
+        ],
+        "year":2023.0,
+        "medgen":[
+            "1824051"
+        ],
+        "orphanet":[
+            "675216"
+        ],
+        "gard":[],
+        "malacard":[
+            "SPN469"
+        ],
+        "webstr_hg38":[
+            "1272528"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[],
+        "disease_description":"Late-onset ataxia, may have episodic onset, downbeat nystagmus, vertigo, neuropathy (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chrX",
@@ -1671,61 +2578,107 @@
         "stop_hg19":146993629,
         "start_t2t":146176665,
         "stop_t2t":146176769,
-        "notes_t2t":"(GGC)35.0",
         "id":"FXS_FMR1",
         "disease_id":"FXS, FXTAS, POF1",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CGG",
-        "pathogenic_motif_reference_orientation":"CGG",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
-        "disease":"Fragile X syndrome (FXS), fragile X-associated tremor\/ataxia syndrome (FXTAS), and fragile X-associated primary ovarian insufficiency FXPOI\/POF1",
+        "reference_motif_reference_orientation":[
+            "CGG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CGG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
+        "disease":"Fragile X syndrome (FXS), fragile X-associated tremor/ataxia syndrome (FXTAS), and fragile X-associated primary ovarian insufficiency FXPOI/POF1",
         "gene":"FMR1",
         "flank_motif":null,
         "locus_structure":"(CGG)*",
-        "Inheritance":"XD",
+        "inheritance":[
+            "XD"
+        ],
         "type":"5' UTR",
-        "location_in_gene":"Exon 2",
-        "normal":"5\u201344",
-        "normal_min":5.0,
-        "normal_max":44.0,
-        "intermediate":"45-200",
+        "location_in_gene":null,
+        "benign_min":5.0,
+        "benign_max":44.0,
         "intermediate_min":45.0,
         "intermediate_max":200.0,
-        "pathogenic":"200-2000",
         "pathogenic_min":200.0,
         "pathogenic_max":2000.0,
         "ref_copies":20.6667,
-        "repeatunitlen":3,
-        "age_onset":"Typical: FXS 1 to \"first several years of life\", FXTAS 60-65 (GeneReview); Range: 0 (FXS, UptoDate) - 78 (PMID: 17427188); detailed description of typical symptom onset and diagnosis available at 10.1007\/978-3-031-66932-3_14",
+        "motif_len":3,
+        "age_onset":"Typical: FXS 1 to \"first several years of life\", FXTAS 60-65 (GeneReview); Range: 0 (FXS, UptoDate) - 78 (PMID: 17427188); detailed description of typical symptom onset and diagnosis available at 10.1007/978-3-031-66932-3_14",
         "age_onset_min":0,
         "age_onset_max":78,
         "typ_age_onset_min":1.0,
         "typ_age_onset_max":65.0,
         "novel":"ref",
-        "Mechanism":"LOF via decreased gene expression in FXS, GOF in FXTAS",
-        "Mechanism_detail":"Loss of function via transcriptional silencing in FXSRNA GOF in FXTAS",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg1691) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, NBK1384",
-        "notes":"FXTAS\/POI 55\u2013200, FXS >200, late onset; AGG and CTG interruptions (GeneReviews & PMID: 29868108)",
-        "details":null,
-        "width":74.0,
-        "OMIM":"300624; 300623",
-        "Prevalence":"14\/100000",
-        "Prevalence_details":"Incidence of full mutation in males 19\/100,000; prevalence 14\/100,000 (GeneReviews). Female prevalence 9\/100,000 (PMID: 24700618). Tang et al., 2017: known carrier frequency 300-500\/100,000 but detected was 11\/100,000. 10.1007\/978-3-031-66932-3_14: FXS prevalence 1:7000 males, 1:11,000 females; FX premutation carriers 1:290-855 males, 1:148-300 females.",
-        "STRipy_gene":"FMR1",
-        "gnomAD_gene":"FMR1",
-        "GeneReviews":"NBK1384",
-        "Mondo":"0010383; 0010706; 0010382",
-        "Year":1991.0,
-        "MedGen":"8912; 1644269; 333403",
-        "Orphanet":"908; 642691; 93256",
-        "GARD":"6464; 16806",
-        "WebSTR_hg38":"885222",
-        "WebSTR_hg19":"Expansion_FXS\/FMR1"
+        "mechanism":"LOF via decreased gene expression in FXS, GOF in FXTAS",
+        "mechanism_detail":"Loss of function via transcriptional silencing in FXSRNA GOF in FXTAS (doi.org/10.1038/nrg1691) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "NBK1384"
+        ],
+        "details":"FXTAS/POI 55-200, FXS >200, late onset; AGG and CTG interruptions (GeneReviews & PMID: 29868108)",
+        "omim":[
+            "300624",
+            "300623"
+        ],
+        "prevalence":"14/100000",
+        "prevalence_details":"Incidence of full mutation in males 19/100,000; prevalence 14/100,000 (GeneReviews). Female prevalence 9/100,000 (PMID: 24700618). Tang et al., 2017: known carrier frequency 300-500/100,000 but detected was 11/100,000. 10.1007/978-3-031-66932-3_14: FXS prevalence 1:7000 males, 1:11,000 females; FX premutation carriers 1:290-855 males, 1:148-300 females. Found worldwide (NBK1384)",
+        "stripy":[
+            "FMR1"
+        ],
+        "gnomad":[
+            "FMR1"
+        ],
+        "genereviews":[
+            "NBK1384"
+        ],
+        "mondo":[
+            "0010383",
+            "0010706",
+            "0010382"
+        ],
+        "year":1991.0,
+        "medgen":[
+            "8912",
+            "1644269",
+            "333403"
+        ],
+        "orphanet":[
+            "908",
+            "642691",
+            "93256"
+        ],
+        "gard":[
+            "6464",
+            "16806"
+        ],
+        "malacard":[
+            "FRG001",
+            "FRG008",
+            "PRM405"
+        ],
+        "webstr_hg38":[
+            "885222"
+        ],
+        "webstr_hg19":[
+            "Expansion_FXS/FMR1"
+        ],
+        "tr_gnomad":[
+            "TR173944"
+        ],
+        "disease_description":"A genetic syndrome caused by mutations in the FMR1 gene which is responsible for the expression of the fragile X mental retardation 1 protein. This protein participates in neural development. This syndrome is manifested with mental, emotional, behavioral, physical, and learning disabilities.; Any primary ovarian failure in which the cause of the disease is a mutation in the FMR1 gene.; Fragile X-associated tremor/ataxia syndrome (FXTAS) is a rare neurodegenerative disorder characterized by adult-onset progressive intention tremor and gait ataxia. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr3",
@@ -1735,61 +2688,89 @@
         "stop_hg19":138664904,
         "start_t2t":141687014,
         "stop_t2t":141687051,
-        "notes_t2t":"(GCGGCTGCAGCCGCA)2.5",
         "id":"BPES_FOXL2",
         "disease_id":"BPES",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Blepharophimosis, epicanthus inversus, and ptosis",
         "gene":"FOXL2",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"<14",
-        "normal_min":14.0,
-        "normal_max":14.0,
-        "intermediate":null,
+        "benign_min":14.0,
+        "benign_max":14.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">15",
         "pathogenic_min":15.0,
         "pathogenic_max":15.0,
         "ref_copies":14.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":0.0,
         "typ_age_onset_max":0.0,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "NBK535148"
+        ],
         "details":null,
-        "width":42.0,
-        "OMIM":"110100",
-        "Prevalence":"0.3\/50000",
-        "Prevalence_details":"1 in 50,000 births globally for all BPES, with FOXL2 expansions 30% of pathogenic variants (NBK1441; NBK535148 (PMID: 12529855))",
-        "STRipy_gene":"FOXL2",
-        "gnomAD_gene":"FOXL2",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0007201",
-        "Year":2001.0,
-        "MedGen":"66312",
-        "Orphanet":"126",
-        "GARD":"23",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":null
+        "omim":[
+            "110100"
+        ],
+        "prevalence":"0.3/50000",
+        "prevalence_details":"1 in 50,000 births globally for all BPES, with FOXL2 expansions 30% of pathogenic variants (NBK1441; NBK535148 (PMID: 12529855)). Found worldwide, without differences in prevalence based on sex/ethnicity (NBK1441).",
+        "stripy":[
+            "FOXL2"
+        ],
+        "gnomad":[
+            "FOXL2"
+        ],
+        "genereviews":[
+            "NBK1441"
+        ],
+        "mondo":[
+            "0007201"
+        ],
+        "year":2001.0,
+        "medgen":[
+            "66312"
+        ],
+        "orphanet":[
+            "126"
+        ],
+        "gard":[
+            "23"
+        ],
+        "malacard":[
+            "BLP046"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR36092"
+        ],
+        "disease_description":"Blepharophimosis, Ptosis, and Epicanthus Inversus syndrome (BPES) is an ophthalmic disorder characterized by blepharophimosis, ptosis, epicanthus inversus, and telecanthus, that can appear associated with (type I) or without premature ovarian failure (POF) (type II). (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr9",
@@ -1799,61 +2780,95 @@
         "stop_hg19":71652220,
         "start_t2t":81210843,
         "stop_t2t":81210861,
-        "notes_t2t":"(AAG)9.7",
         "id":"FRDA_FXN",
         "disease_id":"FRDA",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GAA",
-        "pathogenic_motif_reference_orientation":"GAA",
-        "pathogenic_motif_gene_orientation":"AAG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GAA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GAA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AAG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Friedreich ataxia",
         "gene":"FXN",
         "flank_motif":"(A)16(GAA)n",
         "locus_structure":"(A)*(GAA)*",
-        "Inheritance":"AR",
+        "inheritance":[
+            "AR"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 1",
-        "normal":"5\u201333",
-        "normal_min":5.0,
-        "normal_max":33.0,
-        "intermediate":"34-65",
+        "benign_min":5.0,
+        "benign_max":33.0,
         "intermediate_min":34.0,
         "intermediate_max":65.0,
-        "pathogenic":"66 to 1700",
         "pathogenic_min":66.0,
         "pathogenic_max":1700.0,
         "ref_copies":6.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 10-15; Range: 2-80 (GeneReview)",
         "age_onset_min":2,
         "age_onset_max":80,
         "typ_age_onset_min":10.0,
         "typ_age_onset_max":15.0,
         "novel":"ref",
-        "Mechanism":"LOF, reduced gene expression",
-        "Mechanism_detail":"Loss of function via transcriptional silencing",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg1691) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK535148",
-        "notes":"Not annotated by TRF? 'The expanded repeats were interrupted either with GAAGAG, GAAGGA, or GAAGAAAA sequences.' (PMID: 11748752)",
-        "details":null,
-        "width":2.0,
-        "OMIM":"229300",
-        "Prevalence":"1\/50000",
-        "Prevalence_details":"1\/50,000 (OMIM); Tang et al., 2017: Known carrier frequency 1000\/100,000; observed 421\/100,000",
-        "STRipy_gene":"FXN",
-        "gnomAD_gene":"FXN",
-        "GeneReviews":"NBK1281",
-        "Mondo":"0100340",
-        "Year":1996.0,
-        "MedGen":"383962",
-        "Orphanet":"95",
-        "GARD":"6468",
-        "WebSTR_hg38":"1509872",
-        "WebSTR_hg19":null
+        "mechanism":"LOF, reduced gene expression",
+        "mechanism_detail":"Loss of function via transcriptional silencing (doi.org/10.1038/nrg1691) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK535148"
+        ],
+        "details":"The expanded repeats were interrupted either with GAAGAG, GAAGGA, or GAAGAAAA sequences (PMID: 11748752)",
+        "omim":[
+            "229300"
+        ],
+        "prevalence":"1/50000",
+        "prevalence_details":"1/50,000 (OMIM); Tang et al., 2017: Known carrier frequency 1000/100,000; observed 421/100,000. Most common inherited ataxia in Europe, the Middle East, India, and North Africa; not documented in Southeast Asia, in sub-Saharan Africa, or among Native Americans (NBK1281)",
+        "stripy":[
+            "FXN"
+        ],
+        "gnomad":[
+            "FXN"
+        ],
+        "genereviews":[
+            "NBK1281"
+        ],
+        "mondo":[
+            "0100340"
+        ],
+        "year":1996.0,
+        "medgen":[
+            "383962"
+        ],
+        "orphanet":[
+            "95"
+        ],
+        "gard":[
+            "6468"
+        ],
+        "malacard":[
+            "FRD001"
+        ],
+        "webstr_hg38":[
+            "1509872"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR93516"
+        ],
+        "disease_description":"Any Friedreich ataxia in which the cause of the disease is a mutation in the FXN gene. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr19",
@@ -1863,61 +2878,92 @@
         "stop_hg19":14606886,
         "start_t2t":14622656,
         "stop_t2t":14622702,
-        "notes_t2t":"(CCG)15.7",
         "id":"OPDM2_GIPC1",
         "disease_id":"OPDM2",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CCG",
-        "pathogenic_motif_reference_orientation":"CCG",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CCG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CCG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Oculopharyngodistal myopathy",
         "gene":"GIPC1",
         "flank_motif":null,
         "locus_structure":"(CCG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
-        "location_in_gene":"Exon 1",
-        "normal":"6-29",
-        "normal_min":6.0,
-        "normal_max":29.0,
-        "intermediate":null,
+        "location_in_gene":null,
+        "benign_min":6.0,
+        "benign_max":29.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"70-138",
         "pathogenic_min":70.0,
         "pathogenic_max":138.0,
         "ref_copies":14.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 20-34 (PMID: 32413282); Range: 14 (PMID: ...282) - 70 (PMID: 33374016)",
         "age_onset_min":14,
         "age_onset_max":70,
         "typ_age_onset_min":20.0,
         "typ_age_onset_max":34.0,
         "novel":"ref",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA mediated toxicity hypothesized; unknown",
-        "Mechanism_source":"(OMIM), (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, 32413282 (Pubmed)",
-        "notes":"Interruptions Seen: CGA (PMID: 35245110); Interruptions mentioned but not confirmed in primary literature: TCG\/CCT\/TTG (PMID: 38467784)",
-        "details":null,
-        "width":33.0,
-        "OMIM":"618940",
-        "Prevalence":null,
-        "Prevalence_details":"Population dependent; presumed rare.",
-        "STRipy_gene":"GIPC1",
-        "gnomAD_gene":"GIPC1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0030134",
-        "Year":2020.0,
-        "MedGen":"1718769",
-        "Orphanet":null,
-        "GARD":"16397",
-        "WebSTR_hg38":"5626440",
-        "WebSTR_hg19":"STR_668861"
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA mediated toxicity hypothesized (OMIM), or unknown (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "32413282 (Pubmed)"
+        ],
+        "details":"Interruptions Seen: CGA (PMID: 35245110); Interruptions mentioned but not confirmed in primary literature: TCG/CCT/TTG (PMID: 38467784)",
+        "omim":[
+            "618940"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Population dependent; presumed rare. Predominantly found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "GIPC1"
+        ],
+        "gnomad":[
+            "GIPC1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0030134"
+        ],
+        "year":2020.0,
+        "medgen":[
+            "1718769"
+        ],
+        "orphanet":[],
+        "gard":[
+            "16397"
+        ],
+        "malacard":[
+            "OCL080"
+        ],
+        "webstr_hg38":[
+            "5626440"
+        ],
+        "webstr_hg19":[
+            "STR_668861"
+        ],
+        "tr_gnomad":[
+            "TR154638"
+        ],
+        "disease_description":"Ptosis, external ophthalmoplegia, facial weakness, and pharyngeal and distal limb weakness (PMID: 38876750); Slowly progressive distal weakness, ophthalmoplegia, facial and bulbar weakness (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr2",
@@ -1927,61 +2973,93 @@
         "stop_hg19":191745646,
         "start_t2t":191369983,
         "stop_t2t":191370024,
-        "notes_t2t":"(GCA)14.0",
         "id":"GDPAG_GLS",
         "disease_id":"GDPAG",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCA",
-        "pathogenic_motif_reference_orientation":"GCA",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Glutaminase deficiency",
         "gene":"GLS",
         "flank_motif":null,
         "locus_structure":"(GCA)*",
-        "Inheritance":"AR",
+        "inheritance":[
+            "AR"
+        ],
         "type":"5' UTR",
-        "location_in_gene":"Exon 1",
-        "normal":"5-26",
-        "normal_min":5.0,
-        "normal_max":26.0,
-        "intermediate":null,
+        "location_in_gene":null,
+        "benign_min":5.0,
+        "benign_max":26.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"90 - 1500",
         "pathogenic_min":90.0,
         "pathogenic_max":1500.0,
         "ref_copies":16.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Early childhood (2-4; PMID: 30970188, 35913761)",
         "age_onset_min":2,
         "age_onset_max":4,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Decreased gene expression, methylation",
-        "Mechanism_detail":"Change in histone modification decreases transcription",
-        "Mechanism_source":"(OMIM)",
-        "source":"van Kuilenburg 2019 NEJM, 30970188 (Pubmed)",
-        "notes":"Several compound het cases reported",
-        "details":null,
-        "width":47.0,
-        "OMIM":"618412",
-        "Prevalence":null,
-        "Prevalence_details":"As of 2019, only 7 cases total of GLS deficiency, including non-repeat",
-        "STRipy_gene":"GLS",
-        "gnomAD_gene":"GLS",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0600001",
-        "Year":2019.0,
-        "MedGen":"987241",
-        "Orphanet":null,
-        "GARD":null,
-        "WebSTR_hg38":"333878; 5494902",
-        "WebSTR_hg19":"STR_803303"
+        "mechanism":"Decreased gene expression, methylation",
+        "mechanism_detail":"Change in histone modification decreases transcription (OMIM)",
+        "source":[
+            "van Kuilenburg 2019 NEJM",
+            "30970188 (Pubmed)"
+        ],
+        "details":"Several compound het cases have been reported",
+        "omim":[
+            "618412"
+        ],
+        "prevalence":null,
+        "prevalence_details":"As of 2019, only 7 cases total of GLS deficiency, including non-repeat. Identified patients have been Canadian (PMID: 30970188), Kurdish (Turkey; PMID: 35913761) and US-American (Northern European/Native American descen; PMID: 35913761)",
+        "stripy":[
+            "GLS"
+        ],
+        "gnomad":[
+            "GLS"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0600001"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "987241"
+        ],
+        "orphanet":[
+            "557056"
+        ],
+        "gard":[],
+        "malacard":[
+            "SPS235"
+        ],
+        "webstr_hg38":[
+            "333878",
+            "5494902"
+        ],
+        "webstr_hg19":[
+            "STR_803303"
+        ],
+        "tr_gnomad":[
+            "TR24838"
+        ],
+        "disease_description":"Glutaminase deficiency is characterized by refractory seizures, respiratory failure, brain abnormalities and death in the neonatal period, though milder cases with spastic ataxia-dysarthria have also been reported. This condition is caused by mutations in the glutaminase (GLS) gene. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr7",
@@ -1991,61 +3069,95 @@
         "stop_hg19":27239585,
         "start_t2t":27335920,
         "stop_t2t":27335951,
-        "notes_t2t":"(GCAGCCGCCGCCGCT)2.7",
         "id":"HFG_HOXA13-I",
         "disease_id":"HFG-I",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Hand-foot-genital syndrome 1",
         "gene":"HOXA13",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"14",
-        "normal_min":14.0,
-        "normal_max":14.0,
-        "intermediate":null,
+        "benign_min":14.0,
+        "benign_max":14.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"22",
         "pathogenic_min":22.0,
         "pathogenic_max":22.0,
         "ref_copies":14.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine ",
-        "Mechanism_detail":"Polyalanine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats, Gnomad v3.1.2, NBK1423",
-        "notes":"There are 3 pathogenic polyalanine tracts in this gene",
-        "details":null,
-        "width":42.0,
-        "OMIM":"140000",
-        "Prevalence":null,
-        "Prevalence_details":"\"Extremely rare\" (GeneReview)",
-        "STRipy_gene":"HOXA13_1",
-        "gnomAD_gene":"HOXA13_1",
-        "GeneReviews":"NBK1423",
-        "Mondo":"0007698",
-        "Year":2000.0,
-        "MedGen":"331103",
-        "Orphanet":"2438",
-        "GARD":"2594",
-        "WebSTR_hg38":"5679832",
-        "WebSTR_hg19":"STR_1311037"
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats",
+            "Gnomad v3.1.2",
+            "NBK1423"
+        ],
+        "details":"There are 3 pathogenic polyalanine tracts in this gene",
+        "omim":[
+            "140000"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Extremely rare, published cases generally European ancestry or unknown (PMID: 15385446; PMID: 17935235, GeneReview)",
+        "stripy":[
+            "HOXA13_1"
+        ],
+        "gnomad":[
+            "HOXA13_1"
+        ],
+        "genereviews":[
+            "NBK1423"
+        ],
+        "mondo":[
+            "0007698"
+        ],
+        "year":2000.0,
+        "medgen":[
+            "331103"
+        ],
+        "orphanet":[
+            "2438"
+        ],
+        "gard":[
+            "2594"
+        ],
+        "malacard":[
+            "HND004"
+        ],
+        "webstr_hg38":[
+            "5679832"
+        ],
+        "webstr_hg19":[
+            "STR_1311037"
+        ],
+        "tr_gnomad":[
+            "TR74138"
+        ],
+        "disease_description":"Hand-foot-genital syndrome (HFGS) is a very rare multiple congenital abnormality syndrome characterized by distal limb malformations and urogenital defects. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr7",
@@ -2055,61 +3167,94 @@
         "stop_hg19":27239480,
         "start_t2t":27335914,
         "stop_t2t":27335954,
-        "notes_t2t":"(GCAGCCGCCGCCGCT)2.9",
         "id":"HFG_HOXA13-II",
         "disease_id":"HFG-II",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Hand-foot-genital syndrome 2",
         "gene":"HOXA13",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"12",
-        "normal_min":12.0,
-        "normal_max":12.0,
-        "intermediate":null,
+        "benign_min":12.0,
+        "benign_max":12.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"18",
         "pathogenic_min":18.0,
         "pathogenic_max":18.0,
         "ref_copies":12.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine ",
-        "Mechanism_detail":"Polyalanine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2,  NBK1423",
-        "notes":"There are 3 pathogenic polyalanine tracts in this gene",
-        "details":null,
-        "width":36.0,
-        "OMIM":"140000",
-        "Prevalence":null,
-        "Prevalence_details":"\"Extremely rare\" (GeneReview)",
-        "STRipy_gene":"HOXA13_2",
-        "gnomAD_gene":"HOXA13_2",
-        "GeneReviews":"NBK1423",
-        "Mondo":"0007698",
-        "Year":2000.0,
-        "MedGen":"331103",
-        "Orphanet":"2438",
-        "GARD":"2594",
-        "WebSTR_hg38":"5679831",
-        "WebSTR_hg19":"STR_1311036"
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK1423"
+        ],
+        "details":"There are 3 pathogenic polyalanine tracts in this gene",
+        "omim":[
+            "140000"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Extremely rare, published cases generally European ancestry or unknown (PMID: 15385446; PMID: 17935235, GeneReview)",
+        "stripy":[
+            "HOXA13_2"
+        ],
+        "gnomad":[
+            "HOXA13_2"
+        ],
+        "genereviews":[
+            "NBK1423"
+        ],
+        "mondo":[
+            "0007698"
+        ],
+        "year":2000.0,
+        "medgen":[
+            "331103"
+        ],
+        "orphanet":[
+            "2438"
+        ],
+        "gard":[
+            "2594"
+        ],
+        "malacard":[
+            "HND004"
+        ],
+        "webstr_hg38":[
+            "5679831"
+        ],
+        "webstr_hg19":[
+            "STR_1311036"
+        ],
+        "tr_gnomad":[
+            "TR74137"
+        ],
+        "disease_description":"Hand-foot-genital syndrome (HFGS) is a very rare multiple congenital abnormality syndrome characterized by distal limb malformations and urogenital defects. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr7",
@@ -2119,61 +3264,94 @@
         "stop_hg19":27239351,
         "start_t2t":27335815,
         "stop_t2t":27335849,
-        "notes_t2t":"(GCCGCGGCCGCCGCCG)1.9",
         "id":"HFG_HOXA13-III",
         "disease_id":"HFG-III",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Hand-foot-genital syndrome 3",
         "gene":"HOXA13",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"8-18",
-        "normal_min":8.0,
-        "normal_max":18.0,
-        "intermediate":null,
+        "benign_min":8.0,
+        "benign_max":18.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"24-32",
         "pathogenic_min":24.0,
         "pathogenic_max":32.0,
         "ref_copies":18.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine ",
-        "Mechanism_detail":"Polyalanine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK1423",
-        "notes":"There are 3 pathogenic polyalanine tracts in this gene",
-        "details":null,
-        "width":54.0,
-        "OMIM":"140000",
-        "Prevalence":null,
-        "Prevalence_details":"\"Extremely rare\" (GeneReview)",
-        "STRipy_gene":"HOXA13_3",
-        "gnomAD_gene":"HOXA13_3",
-        "GeneReviews":"NBK1423",
-        "Mondo":"0007698",
-        "Year":2000.0,
-        "MedGen":"331103",
-        "Orphanet":"2438",
-        "GARD":"2594",
-        "WebSTR_hg38":"1365344",
-        "WebSTR_hg19":"STR_1311035"
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK1423"
+        ],
+        "details":"There are 3 pathogenic polyalanine tracts in this gene",
+        "omim":[
+            "140000"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Extremely rare, published cases generally European ancestry or unknown (PMID: 15385446; PMID: 17935235, GeneReview)",
+        "stripy":[
+            "HOXA13_3"
+        ],
+        "gnomad":[
+            "HOXA13_3"
+        ],
+        "genereviews":[
+            "NBK1423"
+        ],
+        "mondo":[
+            "0007698"
+        ],
+        "year":2000.0,
+        "medgen":[
+            "331103"
+        ],
+        "orphanet":[
+            "2438"
+        ],
+        "gard":[
+            "2594"
+        ],
+        "malacard":[
+            "HND004"
+        ],
+        "webstr_hg38":[
+            "1365344"
+        ],
+        "webstr_hg19":[
+            "STR_1311035"
+        ],
+        "tr_gnomad":[
+            "TR74136"
+        ],
+        "disease_description":"Hand-foot-genital syndrome (HFGS) is a very rare multiple congenital abnormality syndrome characterized by distal limb malformations and urogenital defects. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr2",
@@ -2183,61 +3361,94 @@
         "stop_hg19":176957831,
         "start_t2t":176581179,
         "stop_t2t":176581220,
-        "notes_t2t":"(GGC)14.0",
         "id":"SD5_HOXD13",
         "disease_id":"SD5",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Syndactyly",
         "gene":"HOXD13",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"< 15",
-        "normal_min":14.0,
-        "normal_max":15.0,
-        "intermediate":null,
+        "benign_min":14.0,
+        "benign_max":15.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">22",
         "pathogenic_min":22.0,
         "pathogenic_max":22.0,
         "ref_copies":14.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
         "details":null,
-        "width":45.0,
-        "OMIM":"186000",
-        "Prevalence":null,
-        "Prevalence_details":"3 individuals (GeneReview)",
-        "STRipy_gene":"HOXD13",
-        "gnomAD_gene":"HOXD13",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0008513",
-        "Year":1996.0,
-        "MedGen":"1809573",
-        "Orphanet":"295195",
-        "GARD":"17358",
-        "WebSTR_hg38":"5486677",
-        "WebSTR_hg19":"STR_796395"
+        "omim":[
+            "186000"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Found across dozens of unrelated families worldwide (PMID: 24038517)",
+        "stripy":[
+            "HOXD13"
+        ],
+        "gnomad":[
+            "HOXD13"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0008513"
+        ],
+        "year":1996.0,
+        "medgen":[
+            "1809573"
+        ],
+        "orphanet":[
+            "295195"
+        ],
+        "gard":[
+            "17358"
+        ],
+        "malacard":[
+            "SYN084"
+        ],
+        "webstr_hg38":[
+            "5486677"
+        ],
+        "webstr_hg19":[
+            "STR_796395"
+        ],
+        "tr_gnomad":[
+            "TR24032"
+        ],
+        "disease_description":"Synpolydactyly (SPD), or syndactyly type II, is defined as a connection between the middle and ring fingers and fourth and fifth toes, variably associated with postaxial polydactyly in the same digits. Minor local anomalies and various metacarpal or metatarsal abnormalities may be present (OMIM: 186000)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr4",
@@ -2247,61 +3458,99 @@
         "stop_hg19":3076667,
         "start_t2t":3073604,
         "stop_t2t":3073694,
-        "notes_t2t":"(CAG)30.3",
         "id":"HD_HTT",
         "disease_id":"HD",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CAG",
-        "pathogenic_motif_reference_orientation":"CAG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Huntington disease",
         "gene":"HTT",
         "flank_motif":"(CAG)nCAACAG(CCG)12",
         "locus_structure":"(CAG)*CAACAG(CCG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"6\u201326",
-        "normal_min":6.0,
-        "normal_max":26.0,
-        "intermediate":"27-35 unstable, 36-39 reduced penetrance",
+        "benign_min":6.0,
+        "benign_max":26.0,
         "intermediate_min":27.0,
         "intermediate_max":39.0,
-        "pathogenic":"40\u2013250 (>60 assocated with onset age <20)",
         "pathogenic_min":40.0,
         "pathogenic_max":250.0,
         "ref_copies":21.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 35-44 (GeneReview); Range: 2-85 (PMID: 21171977)",
         "age_onset_min":2,
         "age_onset_max":85,
         "typ_age_onset_min":35.0,
         "typ_age_onset_max":44.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine ",
-        "Mechanism_detail":"Polyglutamine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews, PMID: 12791042",
-        "notes":"CAG exp only pathogenic. Interruptions impact pathogenicity (like CAA, PMID: 35245110).",
-        "details":null,
-        "width":63.0,
-        "OMIM":"143100",
-        "Prevalence":"1\/10000",
-        "Prevalence_details":"Tang et al., 2017: 6.5-15\/100,000; 9.71-17:100,000 (European) vs. 0.1-2\/100,000 (African), as many as 1 in 400 have reduced penetrance (0.2-2% for 36-38 CAG) HTT alleles (GeneReview)",
-        "STRipy_gene":"HTT",
-        "gnomAD_gene":"HTT",
-        "GeneReviews":"NBK1305",
-        "Mondo":"0007739",
-        "Year":1993.0,
-        "MedGen":"5654",
-        "Orphanet":"399",
-        "GARD":"6677",
-        "WebSTR_hg38":"4701738; 86468; 86467",
-        "WebSTR_hg19":"Expansion_HD\/HTT"
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews",
+            "PMID: 12791042"
+        ],
+        "details":"27-35 motifs are unstable, 36-39 motifs have reduced penetrance. >60 motifs assocated with onset age <20 years. Only CAG expansions are considered pathogenic. Interruptions impact pathogenicity (e.g. CAA, PMID: 35245110).",
+        "omim":[
+            "143100"
+        ],
+        "prevalence":"1/10000",
+        "prevalence_details":"Tang et al., 2017: 6.5-15/100,000; 9.71-17:100,000 (European) vs. 0.1-2/100,000 (African), as many as 1 in 400 have reduced penetrance (0.2-2% for 36-38 CAG) HTT alleles (GeneReview). Found across ethnicities/ancestries, with population-dependent prevalence (NBK1305)",
+        "stripy":[
+            "HTT"
+        ],
+        "gnomad":[
+            "HTT"
+        ],
+        "genereviews":[
+            "NBK1305"
+        ],
+        "mondo":[
+            "0007739"
+        ],
+        "year":1993.0,
+        "medgen":[
+            "5654"
+        ],
+        "orphanet":[
+            "399"
+        ],
+        "gard":[
+            "6677"
+        ],
+        "malacard":[
+            "HNT016"
+        ],
+        "webstr_hg38":[
+            "4701738",
+            "86468",
+            "86467"
+        ],
+        "webstr_hg19":[
+            "Expansion_HD/HTT"
+        ],
+        "tr_gnomad":[
+            "TR40017",
+            "TR40018"
+        ],
+        "disease_description":"Huntington disease (HD) is a rare neurodegenerative disorder of the central nervous system characterized by unwanted choreatic movements, behavioral and psychiatric disturbances and dementia. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr16",
@@ -2311,61 +3560,96 @@
         "stop_hg19":87637935,
         "start_t2t":93675724,
         "stop_t2t":93675776,
-        "notes_t2t":"(GCT)17.3",
         "id":"HDL2_JPH3",
         "disease_id":"HDL2",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CTG",
-        "pathogenic_motif_reference_orientation":"CTG",
-        "pathogenic_motif_gene_orientation":"CTG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CTG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Huntington disease-like 2",
         "gene":"JPH3",
         "flank_motif":null,
         "locus_structure":"(CTG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 2",
-        "normal":"6\u201328",
-        "normal_min":6.0,
-        "normal_max":28.0,
-        "intermediate":"29-39",
+        "benign_min":6.0,
+        "benign_max":28.0,
         "intermediate_min":29.0,
         "intermediate_max":39.0,
-        "pathogenic":"40\u201358",
         "pathogenic_min":40.0,
         "pathogenic_max":58.0,
         "ref_copies":15.6667,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 30-52; Range: 12-66 (GeneReview)",
         "age_onset_min":12,
         "age_onset_max":66,
         "typ_age_onset_min":30.0,
         "typ_age_onset_max":52.0,
         "novel":"ref",
-        "Mechanism":"LoF\/GoF (RNA)",
-        "Mechanism_detail":"\"unstable vertical transmission\"",
-        "Mechanism_source":"(doi.org\/10.1007\/s11604-022-01343-5), PMID: 38467784",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK1529",
-        "notes":"reflen + pos from HipSTR",
+        "mechanism":"LoF/GoF (RNA)",
+        "mechanism_detail":"unstable vertical transmission (doi.org/10.1007/s11604-022-01343-5), PMID: 38467784",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK1529"
+        ],
         "details":null,
-        "width":46.0,
-        "OMIM":"606438",
-        "Prevalence":null,
-        "Prevalence_details":"<1\/1,000,000 (Orphanet); largely in individuals of African descent",
-        "STRipy_gene":"JPH3",
-        "gnomAD_gene":"JPH3",
-        "GeneReviews":"NBK1529",
-        "Mondo":"0011671",
-        "Year":2001.0,
-        "MedGen":"341120",
-        "Orphanet":"98934",
-        "GARD":"16874",
-        "WebSTR_hg38":"828516; 5987878",
-        "WebSTR_hg19":"Expansion_HDL2\/JPH3"
+        "omim":[
+            "606438"
+        ],
+        "prevalence":null,
+        "prevalence_details":"<1/1,000,000 (Orphanet); largely in individuals of African ancestry (NBK1529)",
+        "stripy":[
+            "JPH3"
+        ],
+        "gnomad":[
+            "JPH3"
+        ],
+        "genereviews":[
+            "NBK1529"
+        ],
+        "mondo":[
+            "0011671"
+        ],
+        "year":2001.0,
+        "medgen":[
+            "341120"
+        ],
+        "orphanet":[
+            "98934"
+        ],
+        "gard":[
+            "16874"
+        ],
+        "malacard":[
+            "HNT004"
+        ],
+        "webstr_hg38":[
+            "828516",
+            "5987878"
+        ],
+        "webstr_hg19":[
+            "Expansion_HDL2/JPH3"
+        ],
+        "tr_gnomad":[
+            "TR143309"
+        ],
+        "disease_description":"Huntington disease-like 2 (HDL2) is a severe neurodegenerative disorder considered part of the neuroacanthocytosis syndromes characterized by a triad of movement, psychiatric, and cognitive abnormalities. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr8",
@@ -2375,61 +3659,98 @@
         "stop_hg19":105601227,
         "start_t2t":105716410,
         "stop_t2t":105716441,
-        "notes_t2t":"(CGC)10.7",
         "id":"OPDM1_LRP12",
         "disease_id":"OPDM1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CGC",
-        "pathogenic_motif_reference_orientation":"CGC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Oculopharyngodistal myopathy type 1",
         "gene":"LRP12",
         "flank_motif":null,
         "locus_structure":"(CGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"13-45",
-        "normal_min":13.0,
-        "normal_max":45.0,
-        "intermediate":null,
+        "benign_min":13.0,
+        "benign_max":45.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"90",
         "pathogenic_min":90.0,
         "pathogenic_max":90.0,
         "ref_copies":11.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 31-51 (PMID: 34047774); Range: 7-66 (PMID: 2124290)",
         "age_onset_min":7,
         "age_onset_max":66,
         "typ_age_onset_min":31.0,
         "typ_age_onset_max":51.0,
         "novel":"ref",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA mediated toxicity hypothesized; unknown",
-        "Mechanism_source":"(OMIM), (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"OMIM 164310, Ishiura et al [2019], Ehdn, NBK535148, PMID 31332380",
-        "notes":"CGG\/CGT; Interruptions Seen: ACG, CCA (PMID: 35245110)",
-        "details":"Possible milder clinical phenotype of inherited peripheral neuropathy (IPN) associated with shorter expansions (https:\/\/doi.org\/10.1212\/WNL.000000000020478)",
-        "width":27.0,
-        "OMIM":"164310",
-        "Prevalence":null,
-        "Prevalence_details":"Population dependent; unknown percentage of LRP12 pathogenic variants.",
-        "STRipy_gene":"LRP12",
-        "gnomAD_gene":"LRP12",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0020793",
-        "Year":2019.0,
-        "MedGen":"1684682",
-        "Orphanet":null,
-        "GARD":"15097",
-        "WebSTR_hg38":"1082178; 4874587",
-        "WebSTR_hg19":"STR_1441036"
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA mediated toxicity hypothesized (OMIM); unknown (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "OMIM 164310",
+            "Ishiura et al [2019]",
+            "Ehdn",
+            "NBK535148",
+            "PMID 31332380"
+        ],
+        "details":"Possible milder clinical phenotype of inherited peripheral neuropathy (IPN) associated with shorter expansions (https://doi.org/10.1212/WNL.000000000020478). Interruptions Seen: ACG, CCA (PMID: 35245110)",
+        "omim":[
+            "164310"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Population dependent; unknown percentage of LRP12 pathogenic variants. Typically East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "LRP12"
+        ],
+        "gnomad":[
+            "LRP12"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0020793"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "1684682"
+        ],
+        "orphanet":[
+            "98897"
+        ],
+        "gard":[
+            "15097"
+        ],
+        "malacard":[
+            "OCL076"
+        ],
+        "webstr_hg38":[
+            "1082178",
+            "4874587"
+        ],
+        "webstr_hg19":[
+            "STR_1441036"
+        ],
+        "tr_gnomad":[
+            "TR88348"
+        ],
+        "disease_description":"Adult-onset ptosis, ophthalmoplegia, facial, distal limb weakness, dysphagia (PMID: 39349043); Ptosis, external ophthalmoplegia, facial weakness, and pharyngeal and distal limb weakness (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr5",
@@ -2439,61 +3760,104 @@
         "stop_hg19":10356523,
         "start_t2t":10295521,
         "stop_t2t":10295593,
-        "notes_t2t":"(TTTTA)14.8",
         "id":"FAME3_MARCHF6",
         "disease_id":"FAME3",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"TTTTA",
-        "pathogenic_motif_reference_orientation":"TTTCA",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"ATGTT,TAGTT,TTTTG,TTTTT",
-        "unknown_motif_gene_orientation":"ATGTT,AGTTT,GTTTT,TTTTT",
+        "reference_motif_reference_orientation":[
+            "TTTTA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TTTCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "ATGTT",
+            "TAGTT",
+            "TTTTG",
+            "TTTTT"
+        ],
+        "unknown_motif_gene_orientation":[
+            "ATGTT",
+            "AGTTT",
+            "GTTTT",
+            "TTTTT"
+        ],
         "disease":"Familial adult myoclonic epilepsy type 3",
         "gene":"MARCHF6",
         "flank_motif":null,
         "locus_structure":"(TTTTA)*(TTTCA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 1",
-        "normal":"0",
-        "normal_min":null,
-        "normal_max":null,
-        "intermediate":null,
+        "benign_min":null,
+        "benign_max":null,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"791-1,035 repeats",
         "pathogenic_min":791.0,
         "pathogenic_max":1035.0,
         "ref_copies":14.8,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 24-41 (PMID: 19616813; based on one 76 member pedigree); Range: 10 (OMIM) - 46 (PMID: 31664039)",
         "age_onset_min":10,
         "age_onset_max":46,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"novel",
-        "Mechanism":"Unknown",
-        "Mechanism_detail":"Noted as unknown in literature",
-        "Mechanism_source":"(OMIM)",
-        "source":"Florian, R.T. Nat Comm. 2019",
-        "notes":"TTTTA + TTTCA",
+        "mechanism":"Unknown",
+        "mechanism_detail":"Noted as unknown in literature (OMIM)",
+        "source":[
+            "Florian",
+            "R.T. Nat Comm. 2019"
+        ],
         "details":null,
-        "width":72.0,
-        "OMIM":"613608",
-        "Prevalence":null,
-        "Prevalence_details":"Overall FAME prevalence is < 1\/35,000; MARCHF6-caused much smaller",
-        "STRipy_gene":"MARCHF6",
-        "gnomAD_gene":"MARCHF6",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0013322",
-        "Year":2019.0,
-        "MedGen":"462210",
-        "Orphanet":"86814",
-        "GARD":"18084",
-        "WebSTR_hg38":"5994579",
-        "WebSTR_hg19":"STR_1116660"
+        "omim":[
+            "613608"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Overall FAME prevalence is < 1/35,000; MARCHF6-caused much smaller. Most cases have European ancestry (PMID: 38876750)",
+        "stripy":[
+            "MARCHF6"
+        ],
+        "gnomad":[
+            "MARCHF6"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0013322"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "462210"
+        ],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "18084"
+        ],
+        "malacard":[
+            "EPL053"
+        ],
+        "webstr_hg38":[
+            "5994579"
+        ],
+        "webstr_hg19":[
+            "STR_1116660"
+        ],
+        "tr_gnomad":[
+            "TR51895"
+        ],
+        "disease_description":"Cortical tremor, seizures with generalised motor (tonic-clonic) onset (PMID: 38876750); Adult-onset cortical tremor with epilepsy (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr15",
@@ -2503,61 +3867,92 @@
         "stop_hg19":23086390,
         "start_t2t":20458505,
         "stop_t2t":20458536,
-        "notes_t2t":"(GCG)10.7",
         "id":"ALS1_NIPA1",
         "disease_id":"ALS1",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCG",
-        "pathogenic_motif_reference_orientation":"GCG",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Amyotrophic lateral sclerosis",
         "gene":"NIPA1",
         "flank_motif":null,
         "locus_structure":"(GCG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
-        "location_in_gene":null,
-        "normal":"6-10",
-        "normal_min":6.0,
-        "normal_max":10.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 1/Intron 1 depending on transcript",
+        "benign_min":6.0,
+        "benign_max":10.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"> 11",
         "pathogenic_min":11.0,
         "pathogenic_max":56.0,
         "ref_copies":10.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 44-60 (PMID: 26777436); Range: 25 (PMID: 22378146) - 77 (PMID: 26777436)",
         "age_onset_min":25,
         "age_onset_max":77,
         "typ_age_onset_min":44.0,
         "typ_age_onset_max":60.0,
         "novel":"ref",
-        "Mechanism":null,
-        "Mechanism_detail":"No information found",
-        "Mechanism_source":"N\/A in GeneCard",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, 30342764 (Pubmed), path range from gnomAD",
-        "notes":"Proposed modifier for ALS",
-        "details":null,
-        "width":24.0,
-        "OMIM":"105400",
-        "Prevalence":null,
-        "Prevalence_details":"2.7-7.4\/100,000 (All ALS, not just this locus), NIPA1 + C9orf72 is 0.37% of ALS patients; frequency of NIPA1 expansion in controls is 3.74% (PMID: 31286297)",
-        "STRipy_gene":"NIPA1",
-        "gnomAD_gene":"NIPA1",
-        "GeneReviews":null,
-        "Mondo":"0007103",
-        "Year":null,
-        "MedGen":"400169",
-        "Orphanet":null,
-        "GARD":null,
-        "WebSTR_hg38":"5135087",
-        "WebSTR_hg19":null
+        "mechanism":null,
+        "mechanism_detail":null,
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "30342764 (Pubmed)",
+            "path range from gnomAD"
+        ],
+        "details":"Proposed modifier for ALS",
+        "omim":[
+            "105400"
+        ],
+        "prevalence":null,
+        "prevalence_details":"2.7-7.4/100,000 (All ALS, not just this locus), NIPA1 + C9orf72 is 0.37% of ALS patients; frequency of NIPA1 expansion in controls is 3.74% (PMID: 31286297). The repeat expansion is associated with disease globally (PMID: 30342764), but likely unassociated in African probands (PMID: 34179866)",
+        "stripy":[
+            "NIPA1"
+        ],
+        "gnomad":[
+            "NIPA1"
+        ],
+        "genereviews":[],
+        "mondo":[
+            "0007103"
+        ],
+        "year":null,
+        "medgen":[
+            "400169"
+        ],
+        "orphanet":[
+            "282",
+            "803"
+        ],
+        "gard":[
+            "5786"
+        ],
+        "malacard":[
+            "FRN044"
+        ],
+        "webstr_hg38":[
+            "5135087"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR133649"
+        ],
+        "disease_description":"Amyotrophic lateral sclerosis is a neurodegenerative disorder characterized by the death of motor neurons in the brain, brainstem, and spinal cord, resulting in fatal paralysis. ALS usually begins with asymmetric involvement of the muscles in middle adult life. (OMIM: 105400)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr20",
@@ -2567,61 +3962,97 @@
         "stop_hg19":2633403,
         "start_t2t":2683200,
         "stop_t2t":2683224,
-        "notes_t2t":"(GCCTGG)8.8",
         "id":"SCA36_NOP56",
         "disease_id":"SCA36",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GGCCTG",
-        "pathogenic_motif_reference_orientation":"GGCCTG",
-        "pathogenic_motif_gene_orientation":"CCTGGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGCCTG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGCCTG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCTGGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar ataxia type 36",
         "gene":"NOP56",
         "flank_motif":"(GGCCTG)n(CGCCTG)3",
         "locus_structure":"(GGCCTG)*(CGCCTG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 1",
-        "normal":"3 to 14",
-        "normal_min":3.0,
-        "normal_max":14.0,
-        "intermediate":"15-649",
+        "benign_min":3.0,
+        "benign_max":14.0,
         "intermediate_min":15.0,
         "intermediate_max":649.0,
-        "pathogenic":"650-2500",
         "pathogenic_min":650.0,
         "pathogenic_max":2500.0,
         "ref_copies":7.2,
-        "repeatunitlen":6,
+        "motif_len":6,
         "age_onset":"Typical: 40-60 (NBK231880); Range: 28 (PMID: 37810464) - 67 (PMID: 37332636)",
         "age_onset_min":28,
         "age_onset_max":67,
         "typ_age_onset_min":40.0,
         "typ_age_onset_max":60.0,
         "novel":"ref",
-        "Mechanism":"Protein toxic GOF",
-        "Mechanism_detail":"toxic gain-of-function mechanism",
-        "Mechanism_source":"(OMIM)",
-        "source":"GeneReviews, OMIM, NBK231880",
-        "notes":"Interruptions: GGCTG, GGCCCTG, GGCCG, and GGCCTTG (PMID: 37051597)",
-        "details":null,
-        "width":42.0,
-        "OMIM":"614153",
-        "Prevalence":null,
-        "Prevalence_details":"Western Japan: 3.6% of all SCA; Costa da Morte region of Spain: 6.3% of all SCA(PMID: 37332636); US: 0.7% of large undiagnosed ataxia cohort (PMID: 28761930)",
-        "STRipy_gene":"NOP56",
-        "gnomAD_gene":"NOP56",
-        "GeneReviews":null,
-        "Mondo":"0013594",
-        "Year":2011.0,
-        "MedGen":"483339",
-        "Orphanet":"276198",
-        "GARD":"12367",
-        "WebSTR_hg38":"6177296; 890490",
-        "WebSTR_hg19":"STR_833720"
+        "mechanism":"Protein toxic GOF",
+        "mechanism_detail":"toxic gain-of-function mechanism (OMIM)",
+        "source":[
+            "GeneReviews",
+            "OMIM",
+            "NBK231880"
+        ],
+        "details":"Interruptions: GGCTG, GGCCCTG, GGCCG, and GGCCTTG (PMID: 37051597)",
+        "omim":[
+            "614153"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Western Japan: 3.6% of all SCA; Costa da Morte region of Spain: 6.3% of all SCA(PMID: 37332636); US: 0.7% of large undiagnosed ataxia cohort (PMID: 28761930). Found across ancestries/ethnicities (OMIM: 614153)",
+        "stripy":[
+            "NOP56"
+        ],
+        "gnomad":[
+            "NOP56"
+        ],
+        "genereviews":[],
+        "mondo":[
+            "0013594"
+        ],
+        "year":2011.0,
+        "medgen":[
+            "483339"
+        ],
+        "orphanet":[
+            "276198"
+        ],
+        "gard":[
+            "12367"
+        ],
+        "malacard":[
+            "SPN265"
+        ],
+        "webstr_hg38":[
+            "6177296",
+            "890490"
+        ],
+        "webstr_hg19":[
+            "STR_833720"
+        ],
+        "tr_gnomad":[
+            "TR157810",
+            "TR157811"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 36 (SCA36) is a subtype of autosomal dominant cerebellar ataxia type 1 (ADCA type 1) characterized by gait and limb ataxia, lower limb spasticity, dysarthria, muscle fasiculations, tongue atrophy and hyperreflexia. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr1",
@@ -2631,61 +4062,91 @@
         "stop_hg19":145209354,
         "start_t2t":148519696,
         "stop_t2t":148519738,
-        "notes_t2t":"(GGC)14.3",
         "id":"NIID_NOTCH2NLC",
         "disease_id":"NIID",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GGC",
-        "pathogenic_motif_reference_orientation":"GGC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Neuronal intranuclear inclusion disease, Alzheimer disease and parkinsonism phenotype",
         "gene":"NOTCH2NLC",
         "flank_motif":null,
         "locus_structure":"(GGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
-        "location_in_gene":"5' Region",
-        "normal":"7\u201339",
-        "normal_min":7.0,
-        "normal_max":39.0,
-        "intermediate":null,
+        "location_in_gene":null,
+        "benign_min":7.0,
+        "benign_max":39.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"66-517",
         "pathogenic_min":66.0,
         "pathogenic_max":517.0,
         "ref_copies":13.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 30-70 (OMIM); Range: 10 (PMID: 37090934) - 78 (PMID: 37305750)",
         "age_onset_min":10,
         "age_onset_max":78,
         "typ_age_onset_min":30.0,
         "typ_age_onset_max":70.0,
         "novel":"ref",
-        "Mechanism":"PolyG\/RNA GoF",
-        "Mechanism_detail":"May relate to methylation or RNA pathogenicity",
-        "Mechanism_source":"(OMIM) (doi.org\/10.1007\/s11604-022-01343-5), PMID: 38467784",
-        "source":"doi: 10.1038\/s41588-019-0458-z, https:\/\/doi.org\/10.1016\/j.ajhg.2019.05.013, s40478-021-01201-x",
-        "notes":"May be issues with parology between genes: C253572.1, NOTCH2, NOTCH2NL, NBPF14, NBPF19 ?? Motif variation in controls: (AGG)(CGG)n(AGG)0-3(CGG)0-2. Methylation involved. GGA and AGC interruptions may influence phenotype (PMID: 34718964); Interruptions Seen: GGA, GGG (PMID: 35245110); ACCGAGAAGATGCCCGCCCTGC interruption mentioned but not confirmed in PMID: 38467784",
-        "details":"Age of onset inversely related to allele size (PMID: 38377026)",
-        "width":39.0,
-        "OMIM":"603472",
-        "Prevalence":null,
-        "Prevalence_details":">400 patients reported in literature (PMID: 37371433)",
-        "STRipy_gene":"NOTCH2NLC",
-        "gnomAD_gene":"NOTCH2NLC",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0011327",
-        "Year":2019.0,
-        "MedGen":"355075",
-        "Orphanet":"2289",
-        "GARD":"3971",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":null
+        "mechanism":"PolyG/RNA GoF",
+        "mechanism_detail":"May relate to methylation or RNA pathogenicity (OMIM) (doi.org/10.1007/s11604-022-01343-5), PMID: 38467784",
+        "source":[
+            "doi: 10.1038/s41588-019-0458-z",
+            "https://doi.org/10.1016/j.ajhg.2019.05.013",
+            "s40478-021-01201-x"
+        ],
+        "details":"Age of onset inversely related to allele size (PMID: 38377026). Motif variation in controls: (AGG)(CGG)n(AGG)0-3(CGG)0-2. Methylation involved. GGA and AGC interruptions may influence phenotype (PMID: 34718964); Interruptions Seen: GGA, GGG (PMID: 35245110); ACCGAGAAGATGCCCGCCCTGC interruption mentioned but not confirmed in PMID: 38467784. Detection may be challenging due to parology between genes: C253572.1, NOTCH2, NOTCH2NL, NBPF14, NBPF19",
+        "omim":[
+            "603472"
+        ],
+        "prevalence":null,
+        "prevalence_details":">400 patients reported in literature (PMID: 37371433). Found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "NOTCH2NLC"
+        ],
+        "gnomad":[
+            "NOTCH2NLC"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0011327"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "355075"
+        ],
+        "orphanet":[
+            "2289"
+        ],
+        "gard":[
+            "3971"
+        ],
+        "malacard":[
+            "NRN008"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR7525"
+        ],
+        "disease_description":"Neuronal intranuclear inclusion disease (NIID) is a very rare multisystem neurodegenerative disorder characterized by the presence of eosinophilic intranuclear inclusions in neuronal and glial cells, and neuronal loss. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr10",
@@ -2695,61 +4156,90 @@
         "stop_hg19":81586160,
         "start_t2t":80695712,
         "stop_t2t":80695748,
-        "notes_t2t":"(GCG)12.7",
         "id":"OPML1_NUTM2B-AS1",
         "disease_id":"OPML1",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GGC",
-        "pathogenic_motif_reference_orientation":"GGC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Oculopharyngeal myopathy with leukoencephalopathy 1",
         "gene":"NUTM2B-AS1",
         "flank_motif":null,
         "locus_structure":"(GGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"lncRNA",
         "location_in_gene":"Exon 1 (noncoding)",
-        "normal":"3-16",
-        "normal_min":3.0,
-        "normal_max":16.0,
-        "intermediate":null,
+        "benign_min":3.0,
+        "benign_max":16.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">700",
         "pathogenic_min":700.0,
         "pathogenic_max":700.0,
         "ref_copies":7.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"15-40 (PMID: 31332380; only characterized in one family)",
         "age_onset_min":15,
         "age_onset_max":40,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA mediated toxicity hypothesized, unknown",
-        "Mechanism_source":"(OMIM) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, Ishiura 2019, doi: 10.1038\/s41588-019-0458-z, https:\/\/doi.org\/10.1038\/s41580-021-00382-6",
-        "notes":"Not in TRF annotation, alt transcript in opposite direction: LOC642361",
-        "details":null,
-        "width":21.0,
-        "OMIM":"618637",
-        "Prevalence":null,
-        "Prevalence_details":"\"Rare\"",
-        "STRipy_gene":"NUTM2B-AS1",
-        "gnomAD_gene":"NUTM2B-AS1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0032843",
-        "Year":2019.0,
-        "MedGen":"1684701",
-        "Orphanet":null,
-        "GARD":null,
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":"STR_173942"
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA mediated toxicity hypothesized, unknown (OMIM) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "Ishiura 2019",
+            "doi: 10.1038/s41588-019-0458-z",
+            "https://doi.org/10.1038/s41580-021-00382-6"
+        ],
+        "details":"Alt transcript in opposite direction: LOC642361",
+        "omim":[
+            "618637"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Rare. Found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "NUTM2B-AS1"
+        ],
+        "gnomad":[
+            "NUTM2B-AS1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0032843"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "1684701"
+        ],
+        "orphanet":[],
+        "gard":[],
+        "malacard":[
+            "OCL077"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[
+            "STR_173942"
+        ],
+        "tr_gnomad":[
+            "TR102881"
+        ],
+        "disease_description":"Oculopharyngodistal myopathy and white matter abnormalities (PMID: 38876750); Ptosis, ophthalmoplegia, dysphagia, dysarthria (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr14",
@@ -2759,61 +4249,96 @@
         "stop_hg19":23790711,
         "start_t2t":17522488,
         "stop_t2t":17522518,
-        "notes_t2t":null,
         "id":"OPMD_PABPN1",
         "disease_id":"OPMD",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Oculopharyngeal muscular dystrophy",
         "gene":"PABPN1",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"AD\/AR",
+        "inheritance":[
+            "AD/AR"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"10",
-        "normal_min":10.0,
-        "normal_max":10.0,
-        "intermediate":null,
+        "benign_min":10.0,
+        "benign_max":10.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"12-17",
-        "pathogenic_min":12.0,
-        "pathogenic_max":17.0,
+        "pathogenic_min":11.0,
+        "pathogenic_max":18.0,
         "ref_copies":7.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 40-59 (PMID: 37519616); Range: 20-79 (PMID: 35112761)",
         "age_onset_min":20,
         "age_onset_max":79,
         "typ_age_onset_min":40.0,
         "typ_age_onset_max":59.0,
         "novel":"ref",
-        "Mechanism":"Polyalanine ",
-        "Mechanism_detail":"Polyalanine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Mirkin 2007, GeneReviews NBK1126, s40478-021-01201-x",
-        "notes":"AR for 11 repeats, AD >12 repeats. Most known patients have (GCG)+, but GCN or any polyalanine may be pathogenic",
-        "details":null,
-        "width":20.0,
-        "OMIM":"164300",
-        "Prevalence":"1\/100000",
-        "Prevalence_details":"Tang et al., 2017: 1\/100,000; population specific; frequency of GCN[11] alleles is 1-2% of North America\/Europe\/Japan (GeneReview)",
-        "STRipy_gene":"PABPN1",
-        "gnomAD_gene":"PABPN1",
-        "GeneReviews":"NBK1126",
-        "Mondo":"0958176",
-        "Year":1998.0,
-        "MedGen":"1054618",
-        "Orphanet":"270",
-        "GARD":"7245",
-        "WebSTR_hg38":"1442709; 5271481",
-        "WebSTR_hg19":"Expansion_OPMD\/PAPBN1"
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Mirkin 2007",
+            "GeneReviews NBK1126",
+            "s40478-021-01201-x"
+        ],
+        "details":"Autosomal dominant when one allele is at least 12 motifs. Autosomal recessive when both alleles are at least 11 motifs. Most known patients have (GCG)+, but GCN or any polyalanine may be pathogenic.",
+        "omim":[
+            "164300"
+        ],
+        "prevalence":"1/100000",
+        "prevalence_details":"Tang et al., 2017: 1/100,000; population specific; frequency of GCN[11] alleles is 1-2% of North America/Europe/Japan (GeneReview). Found worldwide, in more than 30 countries (NBK1126)",
+        "stripy":[
+            "PABPN1"
+        ],
+        "gnomad":[
+            "PABPN1"
+        ],
+        "genereviews":[
+            "NBK1126"
+        ],
+        "mondo":[
+            "0958176"
+        ],
+        "year":1998.0,
+        "medgen":[
+            "1054618"
+        ],
+        "orphanet":[
+            "270"
+        ],
+        "gard":[
+            "7245"
+        ],
+        "malacard":[
+            "OCL088"
+        ],
+        "webstr_hg38":[
+            "1442709",
+            "5271481"
+        ],
+        "webstr_hg19":[
+            "Expansion_OPMD/PAPBN1"
+        ],
+        "tr_gnomad":[
+            "TR128439"
+        ],
+        "disease_description":"Ptosis and dysphagia (PMID: 39349043); facial weakness, ptosis (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr4",
@@ -2823,61 +4348,95 @@
         "stop_hg19":41748049,
         "start_t2t":41719745,
         "stop_t2t":41719805,
-        "notes_t2t":"(GCC)15.7",
         "id":"CCHS_PHOX2B",
         "disease_id":"CCHS",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Congenital central hypoventilation syndrome",
         "gene":"PHOX2B",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 3",
-        "normal":"20",
-        "normal_min":15.0,
-        "normal_max":20.0,
-        "intermediate":"24",
+        "benign_min":15.0,
+        "benign_max":20.0,
         "intermediate_min":24.0,
         "intermediate_max":24.0,
-        "pathogenic":"25-33",
         "pathogenic_min":25.0,
         "pathogenic_max":33.0,
         "ref_copies":15.7,
-        "repeatunitlen":3,
-        "age_onset":"Typical: 0-2 (GeneReview\/PMID: 15121777); Range: 0-36 (PMID: 16873766)",
+        "motif_len":3,
+        "age_onset":"Typical: 0-2 (GeneReview/PMID: 15121777); Range: 0-36 (PMID: 16873766)",
         "age_onset_min":0,
         "age_onset_max":36,
         "typ_age_onset_min":0.0,
         "typ_age_onset_max":2.0,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Mirkin 2007, GeneReviews NBK1427, s40478-021-01201-x",
-        "notes":"ReferenceRegion: 4:41745971-41746032",
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Mirkin 2007",
+            "GeneReviews NBK1427",
+            "s40478-021-01201-x"
+        ],
         "details":null,
-        "width":46.0,
-        "OMIM":"209880",
-        "Prevalence":null,
-        "Prevalence_details":"Incidence is 1:148000-200000 births (Estimated, may include mild\/undiagnosed or be overestimate globally) (GeneReview)",
-        "STRipy_gene":"PHOX2B",
-        "gnomAD_gene":"PHOX2B",
-        "GeneReviews":"NBK1427",
-        "Mondo":"0800026",
-        "Year":2003.0,
-        "MedGen":"1794285",
-        "Orphanet":"661",
-        "GARD":"8535",
-        "WebSTR_hg38":"4725362",
-        "WebSTR_hg19":"Expansion_CCHS\/PHOX2B"
+        "omim":[
+            "209880"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Incidence is 1:148000-200000 births (Estimated, may include mild/undiagnosed or be overestimate globally) (GeneReview). Rare, but reported worldwide (PMID: 15121777)",
+        "stripy":[
+            "PHOX2B"
+        ],
+        "gnomad":[
+            "PHOX2B"
+        ],
+        "genereviews":[
+            "NBK1427"
+        ],
+        "mondo":[
+            "0800026"
+        ],
+        "year":2003.0,
+        "medgen":[
+            "1794285"
+        ],
+        "orphanet":[
+            "661"
+        ],
+        "gard":[
+            "8535"
+        ],
+        "malacard":[
+            "CNT119"
+        ],
+        "webstr_hg38":[
+            "4725362"
+        ],
+        "webstr_hg19":[
+            "Expansion_CCHS/PHOX2B"
+        ],
+        "tr_gnomad":[
+            "TR42548"
+        ],
+        "disease_description":"A rare disease due to a severely impaired central autonomic control of breathing and dysfunction of the autonomous nervous system. The incidence is estimated to be at 1 of 200 000 livebirths. A heterozygous mutation of PHOX-2B gene is found in 90% of the patients. Association with a Hirschsprung's disease is observed in 16% of the cases. (adapted from Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr15",
@@ -2887,61 +4446,94 @@
         "stop_hg19":89876860,
         "start_t2t":87088412,
         "stop_t2t":87088452,
-        "notes_t2t":"(GCT)13.7",
         "id":"CPEO_POLG",
         "disease_id":"CPEO",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GCT",
-        "pathogenic_motif_reference_orientation":"GCT",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCT"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCT"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Progressive external ophthalmoplegia, Parkinson\u2019s disease",
         "gene":"POLG",
         "flank_motif":null,
         "locus_structure":"(CTG)*TTG(CTG)*",
-        "Inheritance":null,
+        "inheritance":[],
         "type":"Coding",
-        "location_in_gene":null,
-        "normal":"10",
-        "normal_min":10.0,
-        "normal_max":10.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 2",
+        "benign_min":10.0,
+        "benign_max":10.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"Deviation from 10 may impart disease risk with variable penetrance",
         "pathogenic_min":null,
         "pathogenic_max":null,
         "ref_copies":13.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 57 (PMID: 20399836) - 59 (PMID: 20826197); Range: 23-87 (PMID: 20399836)",
         "age_onset_min":23,
         "age_onset_max":87,
         "typ_age_onset_min":57.0,
         "typ_age_onset_max":59.0,
         "novel":"ref",
-        "Mechanism":null,
-        "Mechanism_detail":"No information found",
-        "Mechanism_source":"N\/A in GeneCard",
-        "source":"PMC2905783, PMID: 20399836, PMID: 10196696",
-        "notes":"Unconfirmed association",
+        "mechanism":null,
+        "mechanism_detail":null,
+        "source":[
+            "PMC2905783",
+            "PMID: 20399836",
+            "PMID: 10196696"
+        ],
         "details":"There is conflicting evidence for the association between this repeat expansion and Parkinson's risk (PMID: 20399836 and PMID: 10196696). Deviation from 10 may impart disease risk with variable penetrance. May be predisposing factor in earlier age of onset in FRDA patients (PMID: 19043662)",
-        "width":40.0,
-        "OMIM":"Disease association unclear",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown",
-        "STRipy_gene":null,
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":"0009783; 0024528",
-        "Year":null,
-        "MedGen":"897191; 371919",
-        "Orphanet":"520820",
-        "GARD":"15215; 13174",
-        "WebSTR_hg38":"5177947",
-        "WebSTR_hg19":"STR_493430"
+        "omim":[
+            "258450",
+            "157640"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Disease association unclear but largely studied in European cohorts/patients (OMIM: 258450/157640)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[
+            "NBK26471"
+        ],
+        "mondo":[
+            "0009783",
+            "0024528"
+        ],
+        "year":null,
+        "medgen":[
+            "897191",
+            "371919"
+        ],
+        "orphanet":[
+            "520820"
+        ],
+        "gard":[
+            "15215",
+            "13174"
+        ],
+        "malacard":[
+            "PRG130",
+            "PRK002"
+        ],
+        "webstr_hg38":[
+            "5177947"
+        ],
+        "webstr_hg19":[
+            "STR_493430"
+        ],
+        "tr_gnomad":[
+            "TR137533"
+        ],
+        "disease_description":"sensory ataxic neuropathy, dysarthria, and ophtalmoparesis (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr5",
@@ -2951,61 +4543,100 @@
         "stop_hg19":146258322,
         "start_t2t":147414734,
         "stop_t2t":147414765,
-        "notes_t2t":"(GCT)15.7",
         "id":"SCA12_PPP2R2B",
         "disease_id":"SCA12",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GCT",
-        "pathogenic_motif_reference_orientation":"GCT",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCT"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCT"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar ataxia type 12",
         "gene":"PPP2R2B",
         "flank_motif":null,
         "locus_structure":"(GCT)*",
-        "Inheritance":"AD",
-        "type":"Promoter",
+        "inheritance":[
+            "AD"
+        ],
+        "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"4\u201332",
-        "normal_min":4.0,
-        "normal_max":32.0,
-        "intermediate":null,
+        "benign_min":4.0,
+        "benign_max":32.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"51\u201378",
         "pathogenic_min":51.0,
         "pathogenic_max":78.0,
         "ref_copies":10.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 26-50; Range: 8-56 (OMIM)",
         "age_onset_min":8,
         "age_onset_max":62,
         "typ_age_onset_min":26.0,
         "typ_age_onset_max":50.0,
         "novel":"ref",
-        "Mechanism":"GoF Polyalanine, RAN translation",
-        "Mechanism_detail":"GoF (PolyA), RAN translation",
-        "Mechanism_source":"PMID: 38467784",
-        "source":"Hannan 2018, Mirkin 2007, OMIM, NBK535148, s40478-021-01201-x",
-        "notes":"(Roda et al. suggested that the ATXN8 or ATXN8OS gene should not be evaluated in isolation as a candidate gene for spinocerebellar degenerative disease)",
+        "mechanism":"GoF Polyalanine, RAN translation",
+        "mechanism_detail":"GoF (PolyA), RAN translation [pmid:38467784]",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "OMIM",
+            "NBK535148",
+            "s40478-021-01201-x"
+        ],
         "details":null,
-        "width":31.0,
-        "OMIM":"604326",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown. Frequent in India; rare in other places (PMID: 34711523)",
-        "STRipy_gene":"PPP2R2B",
-        "gnomAD_gene":"PPP2R2B",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0011439",
-        "Year":1999.0,
-        "MedGen":"347653",
-        "Orphanet":"98762",
-        "GARD":"10476",
-        "WebSTR_hg38":"985593; 6072892",
-        "WebSTR_hg19":"Expansion_SCA12\/PPP2R2B"
+        "omim":[
+            "604326"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Frequent in India; rare in other populations (PMID: 34711523)",
+        "stripy":[
+            "PPP2R2B"
+        ],
+        "gnomad":[
+            "PPP2R2B"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0011439"
+        ],
+        "year":1999.0,
+        "medgen":[
+            "347653"
+        ],
+        "orphanet":[
+            "98762"
+        ],
+        "gard":[
+            "10476"
+        ],
+        "malacard":[
+            "SPN293"
+        ],
+        "webstr_hg38":[
+            "985593",
+            "6072892"
+        ],
+        "webstr_hg19":[
+            "Expansion_SCA12/PPP2R2B"
+        ],
+        "tr_gnomad":[
+            "TR59714"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 12 (SCA12) is a very rare subtype of type I autosomal dominant cerebellar ataxia (ADCA type I). It is characterized by the presence of action tremor associated with relatively mild cerebellar ataxia. Associated pyramidal and extrapyramidal signs and dementia have been reported. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr9",
@@ -3015,61 +4646,94 @@
         "stop_hg19":133557026,
         "start_t2t":142886569,
         "stop_t2t":142886595,
-        "notes_t2t":"(CGC)9.0",
         "id":"HSAN-VIII_PRDM12",
         "disease_id":"HSAN VIII",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCC",
-        "pathogenic_motif_reference_orientation":"GCC",
-        "pathogenic_motif_gene_orientation":"CCG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Hereditary sensory and autonomic neuropathy type VIII",
         "gene":"PRDM12",
         "flank_motif":null,
         "locus_structure":"(GCC)*",
-        "Inheritance":"AR",
+        "inheritance":[
+            "AR"
+        ],
         "type":"Coding",
-        "location_in_gene":"Exon",
-        "normal":"<14",
-        "normal_min":12.0,
-        "normal_max":14.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 5",
+        "benign_min":12.0,
+        "benign_max":14.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">18",
         "pathogenic_min":18.0,
         "pathogenic_max":19.0,
         "ref_copies":12.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"LOF, epigenetic",
-        "Mechanism_detail":"\"mutations abrogated the histone-modifying potential of PRDM12, consistent with a loss of function\"",
-        "Mechanism_source":"OMIM",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, https:\/\/doi.org\/10.1038\/ng.3308",
-        "notes":null,
+        "mechanism":"LOF, epigenetic",
+        "mechanism_detail":"mutations abrogated the histone-modifying potential of PRDM12, consistent with a loss of function (OMIM)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "https://doi.org/10.1038/ng.3308"
+        ],
         "details":null,
-        "width":33.0,
-        "OMIM":"616488",
-        "Prevalence":null,
-        "Prevalence_details":"Found in 2 families. All PRDM12 disease mutations < 1\/1,000,000",
-        "STRipy_gene":"PRDM12",
-        "gnomAD_gene":"PRDM12",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0014662",
-        "Year":null,
-        "MedGen":"894363",
-        "Orphanet":"478664",
-        "GARD":"17866",
-        "WebSTR_hg38":"1543400",
-        "WebSTR_hg19":"STR_1521945"
+        "omim":[
+            "616488"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Repeat expansion found in 2 families from Pakistan and Saudi Arabia (PMID: 26005867). All PRDM12 disease mutations < 1/1,000,000",
+        "stripy":[
+            "PRDM12"
+        ],
+        "gnomad":[
+            "PRDM12"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0014662"
+        ],
+        "year":null,
+        "medgen":[
+            "894363"
+        ],
+        "orphanet":[
+            "478664"
+        ],
+        "gard":[
+            "17866"
+        ],
+        "malacard":[
+            "NRP044"
+        ],
+        "webstr_hg38":[
+            "1543400"
+        ],
+        "webstr_hg19":[
+            "STR_1521945"
+        ],
+        "tr_gnomad":[
+            "TR97506"
+        ],
+        "disease_description":"A hereditary sensory neuropathy characterized by congenital insensitivity to pain and decreased sweating and tear production that has material basis in homozygous mutation in the PRDM12 gene on chromosome 9q34. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr20",
@@ -3079,61 +4743,177 @@
         "stop_hg19":4680139,
         "start_t2t":4738633,
         "stop_t2t":4738705,
-        "notes_t2t":null,
         "id":"CJD_PRNP",
         "disease_id":"CJD",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GGTGGTGGCTGGGGGCAGCCTCAT",
-        "pathogenic_motif_reference_orientation":"CCTCATGGTGGTGGCTGGGGGCAG",
-        "pathogenic_motif_gene_orientation":"AGCCTCATGGTGGTGGCTGGGGGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGTGGTGGCTGGGGGCAGCCTCAT"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CCTCATGGTGGTGGCTGGGGGCAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGCCTCATGGTGGTGGCTGGGGGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Creutzfeldt-Jakob disease",
         "gene":"PRNP",
         "flank_motif":"(CCTCAGGGCGGTGGTGGCTGGGGGCAG)1(CCTCATGGTGGTGGCTGGGGGCAG)n",
         "locus_structure":"(CCTCAGGGCGGTGGTGGCTGGGGGCAG)*(CCTCATGGTGGTGGCTGGGGGCAG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 2",
-        "normal":"<=4",
-        "normal_min":null,
-        "normal_max":4.0,
-        "intermediate":null,
+        "benign_min":null,
+        "benign_max":4.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">=5",
         "pathogenic_min":5.0,
         "pathogenic_max":null,
         "ref_copies":null,
-        "repeatunitlen":24,
+        "motif_len":24,
         "age_onset":"Typical: 50-60 (GeneReview); Range: 31-63 (PMID: 37379724)",
         "age_onset_min":31,
         "age_onset_max":63,
         "typ_age_onset_min":50.0,
         "typ_age_onset_max":60.0,
         "novel":null,
-        "Mechanism":null,
-        "Mechanism_detail":null,
-        "Mechanism_source":null,
-        "source":"https:\/\/www.ncbi.nlm.nih.gov\/books\/NBK1229\/",
-        "notes":null,
+        "mechanism":null,
+        "mechanism_detail":null,
+        "source":[
+            "https://www.ncbi.nlm.nih.gov/books/NBK1229/"
+        ],
         "details":null,
-        "width":null,
-        "OMIM":"123400",
-        "Prevalence":null,
-        "Prevalence_details":"<0.0225\/1,000,000: <15% of CJ variants are repeat expansions (NBK535148). 15% newly diagnosed prion disease cases are genetic (GeneReview) 1 individual per million per year worldwide (350 cases annually in US) (PMID: 29939637)",
-        "STRipy_gene":null,
-        "gnomAD_gene":"PRNP",
-        "GeneReviews":"NBK1229",
-        "Mondo":"0007403",
-        "Year":null,
-        "MedGen":"155837",
-        "Orphanet":"282166",
-        "GARD":"17307",
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":null
+        "omim":[
+            "123400"
+        ],
+        "prevalence":null,
+        "prevalence_details":"<0.0225/1,000,000: <15% of CJ variants are repeat expansions (NBK535148). 15% newly diagnosed prion disease cases are genetic (GeneReview) 1 individual per million per year worldwide (350 cases annually in US) (PMID: 29939637). Found worldwide (NBK1229).",
+        "stripy":[],
+        "gnomad":[
+            "PRNP"
+        ],
+        "genereviews":[
+            "NBK1229"
+        ],
+        "mondo":[
+            "0007403"
+        ],
+        "year":null,
+        "medgen":[
+            "155837"
+        ],
+        "orphanet":[
+            "282166"
+        ],
+        "gard":[
+            "17307"
+        ],
+        "malacard":[
+            "CRT072"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR157963",
+            "TR157964"
+        ],
+        "disease_description":"Inherited or familial Creutzfeldt-Jakob disease (fCJD) is a very rare form of genetic prion disease characterized by typical CJD features (rapidly progressive dementia, personality/behavioral changes, psychiatric disorders, myoclonus, and ataxia) with a genetic cause and sometimes a family history of dementia. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
+    },
+    {
+        "chrom":"chr17",
+        "start_hg38":17808359,
+        "stop_hg38":17808460,
+        "start_hg19":17711673,
+        "stop_hg19":17711774,
+        "start_t2t":17754962,
+        "stop_t2t":17755019,
+        "id":"FAME8_RAI1",
+        "disease_id":"FAME8",
+        "gene_strand":"+",
+        "reference_motif_reference_orientation":[
+            "TTTTA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TTTCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[
+            "TTTTA"
+        ],
+        "benign_motif_gene_orientation":[
+            "ATTTT"
+        ],
+        "unknown_motif_reference_orientation":[
+            "GGGGT",
+            "GGGAT"
+        ],
+        "unknown_motif_gene_orientation":[
+            "GGGGT",
+            "ATGGG"
+        ],
+        "disease":"Familial adult myoclonic epilepsy type 8",
+        "gene":"RAI1",
+        "flank_motif":null,
+        "locus_structure":"(ATTTT)*(TTTCA)*",
+        "inheritance":[
+            "AD"
+        ],
+        "type":"Intronic",
+        "location_in_gene":"Intron 4",
+        "benign_min":null,
+        "benign_max":null,
+        "intermediate_min":null,
+        "intermediate_max":null,
+        "pathogenic_min":9.0,
+        "pathogenic_max":334.0,
+        "ref_copies":20.8,
+        "motif_len":5,
+        "age_onset":"7-68 (one family)",
+        "age_onset_min":7,
+        "age_onset_max":68,
+        "typ_age_onset_min":null,
+        "typ_age_onset_max":null,
+        "novel":"novel",
+        "mechanism":"Unknown",
+        "mechanism_detail":"Expression isn't changed (https://doi.org/10.1002/mds.29654)",
+        "source":[
+            "https://doi.org/10.1002/mds.29654",
+            "PMID: 38876750"
+        ],
+        "details":"TTTTA repeat expansions and TTTCA repeat insertions in intron 4 of the RAI1 gene that co-segregated with disease status in a single large family from Mali (PMID: 37994247). Ten affected individuals were studied. Both TTTTA and TTTCA motifs were observed in all eight of the affected individuals with spanning reads, with allele sizes in the range: (TTTTA)278-773(TTTCA)9-334. A single individual was observed with additional motifs and interruptions in one allele with the structure: (TTTTA)exp(GGGGT)ins(GGGAT)ins(TTTCA)ins. TTTCA repeats were absent in 200 Malian controls, who had alleles in the range: (TTTCA)16-20. Reviewed in (PMID: 38876750). It is uncertain if expansions at both the TTTTA and TTTCA motifs, or only the TTTCA motif are required for pathogogenicity. The pathogenic range in STRchive is for the TTTCA motif only. Note, locus is partially deleted in T2T reference genome",
+        "omim":[],
+        "prevalence":null,
+        "prevalence_details":"Observed in a single family from Mali with ten affected individuals (PMID: 37994247)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[],
+        "year":2024.0,
+        "medgen":[],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "16758"
+        ],
+        "malacard":[],
+        "webstr_hg38":[
+            "486849"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[],
+        "disease_description":"Cortical tremor, seizures with generalised motor (tonic-clonic) onset (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr4",
@@ -3143,61 +4923,102 @@
         "stop_hg19":160263770,
         "start_t2t":162693304,
         "stop_t2t":162693405,
-        "notes_t2t":"(TTTTA)20.4",
         "id":"FAME7_RAPGEF2",
         "disease_id":"FAME7",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"TTTTA",
-        "pathogenic_motif_reference_orientation":"TTTCA",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"TTTTT,TTATG",
-        "unknown_motif_gene_orientation":"TTTTT,ATGTT",
+        "reference_motif_reference_orientation":[
+            "TTTTA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TTTCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "TTTTT",
+            "TTATG"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT",
+            "ATGTT"
+        ],
         "disease":"Familial adult myoclonic epilepsy type 7",
         "gene":"RAPGEF2",
         "flank_motif":null,
         "locus_structure":"(TTTTA)*(TTTCA)*(TTTTA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 14",
-        "normal":"0-1",
-        "normal_min":0.0,
-        "normal_max":1.0,
-        "intermediate":null,
+        "benign_min":0.0,
+        "benign_max":1.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">=60",
         "pathogenic_min":60.0,
         "pathogenic_max":60.0,
         "ref_copies":17.4,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 20-33 (PMID: 30351492); Range: 18 (PMID: 29507423) - 37 (PMID: 30351492)",
         "age_onset_min":18,
         "age_onset_max":37,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"novel",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA toxicity hypothesized",
-        "Mechanism_source":"(10.1038\/s41588-018-0067-2)",
-        "source":"Ishiura 2018, 29507423 (Pubmed), https:\/\/sci-hub.hkvisa.net\/10.1111\/ene.13848",
-        "notes":"Novel, (TTTTA)exp(TTTCA)exp(TTTTA)n, but only the TTTCA is specific to affected individuals, Alu-associated repeat, incomplete penetrance. Interruptions Seen: TATTA, TTTTTA (PMID: 35245110)",
-        "details":null,
-        "width":91.0,
-        "OMIM":"618075",
-        "Prevalence":null,
-        "Prevalence_details":"FAME overall is 1\/35,000 in Japan",
-        "STRipy_gene":"RAPGEF2",
-        "gnomAD_gene":"RAPGEF2",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0054847",
-        "Year":2018.0,
-        "MedGen":"1648435",
-        "Orphanet":"86814",
-        "GARD":"16758",
-        "WebSTR_hg38":"154264; 4792219",
-        "WebSTR_hg19":"STR_1096016"
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA toxicity hypothesized (10.1038/s41588-018-0067-2)",
+        "source":[
+            "Ishiura 2018",
+            "29507423 (Pubmed)",
+            "https://sci-hub.hkvisa.net/10.1111/ene.13848"
+        ],
+        "details":"Novel, (TTTTA)exp(TTTCA)exp(TTTTA)n, but only the TTTCA is specific to affected individuals, Alu-associated repeat, incomplete penetrance. Interruptions Seen: TATTA, TTTTTA (PMID: 35245110)",
+        "omim":[
+            "618075"
+        ],
+        "prevalence":null,
+        "prevalence_details":"FAME overall is 1/35,000 in Japan. Repeat expansion found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "RAPGEF2"
+        ],
+        "gnomad":[
+            "RAPGEF2"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0054847"
+        ],
+        "year":2018.0,
+        "medgen":[
+            "1648435"
+        ],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "16758"
+        ],
+        "malacard":[
+            "EPL228"
+        ],
+        "webstr_hg38":[
+            "154264",
+            "4792219"
+        ],
+        "webstr_hg19":[
+            "STR_1096016"
+        ],
+        "tr_gnomad":[
+            "TR49300"
+        ],
+        "disease_description":"Cortical tremor, seizures with generalised motor (tonic-clonic) onset (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr4",
@@ -3207,61 +5028,146 @@
         "stop_hg19":39350103,
         "start_t2t":39318078,
         "stop_t2t":39318136,
-        "notes_t2t":"(AAAAG)11.8",
         "id":"CANVAS_RFC1",
         "disease_id":"CANVAS",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"AAAAG",
-        "pathogenic_motif_reference_orientation":"AAGGG,ACAGG,AGGGC,AAGGC,AGAGG",
-        "pathogenic_motif_gene_orientation":"CCCTT,CCTGT,CCCTG,CCTTG,CCTCT",
-        "benign_motif_reference_orientation":"AAAAG,AAAGG,AAGAG",
-        "benign_motif_gene_orientation":"CTTTT,CCTTT,CTCTT",
-        "unknown_motif_reference_orientation":"AAAAA,AAAAC,AACGG,AAGAC,AAGGT,AGAAC,AGGGG,GAAAC,GGGAC,GTGAG,AAAAGA,AAAGGA,GGAAAG",
-        "unknown_motif_gene_orientation":"TTTTT,GTTTT,CCGTT,CTTGT,ACCTT,CTGTT,CCCCT,CGTTT,CCCGT,ACCTC,CTTTTT,CCTTTT,CCCTTT",
+        "reference_motif_reference_orientation":[
+            "AAAAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "AAGGG",
+            "ACAGG",
+            "AGGGC",
+            "AAGGC",
+            "AGAGG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCCTT",
+            "CCTGT",
+            "CCCTG",
+            "CCTTG",
+            "CCTCT"
+        ],
+        "benign_motif_reference_orientation":[
+            "AAAAG",
+            "AAAGG",
+            "AAGAG"
+        ],
+        "benign_motif_gene_orientation":[
+            "CTTTT",
+            "CCTTT",
+            "CTCTT"
+        ],
+        "unknown_motif_reference_orientation":[
+            "AAAAA",
+            "AAAAC",
+            "AACGG",
+            "AAGAC",
+            "AAGGT",
+            "AGAAC",
+            "AGGGG",
+            "GAAAC",
+            "GGGAC",
+            "GTGAG",
+            "AAAAGA",
+            "AAAGGA",
+            "GGAAAG"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT",
+            "GTTTT",
+            "CCGTT",
+            "CTTGT",
+            "ACCTT",
+            "CTGTT",
+            "CCCCT",
+            "CGTTT",
+            "CCCGT",
+            "ACCTC",
+            "CTTTTT",
+            "CCTTTT",
+            "CCCTTT"
+        ],
         "disease":"Cerebellar ataxia, neuropathy, and vestibular areflexia syndrome",
         "gene":"RFC1",
         "flank_motif":null,
         "locus_structure":"(AAGGG)*(ACAGG)*",
-        "Inheritance":"AR",
+        "inheritance":[
+            "AR"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 2",
-        "normal":"0-11",
-        "normal_min":0.0,
-        "normal_max":11.0,
-        "intermediate":null,
+        "benign_min":0.0,
+        "benign_max":11.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">400",
         "pathogenic_min":400.0,
         "pathogenic_max":2000.0,
         "ref_copies":11.8,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 36-52; Range: 19-76 (GeneReviews)",
         "age_onset_min":19,
         "age_onset_max":76,
         "typ_age_onset_min":36.0,
         "typ_age_onset_max":52.0,
         "novel":"novel",
-        "Mechanism":"LoF",
-        "Mechanism_detail":"LoF",
-        "Mechanism_source":"PMID: 38467784",
-        "source":"OMIM, Cortese 2019, 30926972 (Pubmed), https:\/\/actaneurocomms.biomedcentral.com\/articles\/10.1186\/s40478-021-01201-x\/tables\/1, s40478-021-01201-x, https:\/\/www.ncbi.nlm.nih.gov\/books\/NBK564656\/, https:\/\/doi.org\/10.1101\/2023.05.12.540470",
-        "notes":"Novel, ref is AAAAG(11), path: (AAGGG)400\u20132000 or (ACAGG)exp",
+        "mechanism":"LoF",
+        "mechanism_detail":"LoF [pmid:38467784]",
+        "source":[
+            "OMIM",
+            "Cortese 2019",
+            "30926972 (Pubmed)",
+            "https://actaneurocomms.biomedcentral.com/articles/10.1186/s40478-021-01201-x/tables/1",
+            "s40478-021-01201-x",
+            "https://www.ncbi.nlm.nih.gov/books/NBK564656/",
+            "https://doi.org/10.1101/2023.05.12.540470"
+        ],
         "details":"Pathogenic expansions may be flanked by other motifs. For example, (AAAGG)10-25(AAGGG)exp(AAAGG)4-6 (PMID: 32851396). Motif heterogeneity is common in unaffected individuals. The pathogenic size threshold appears to differ for the AAAGG motif. AAAGG expansions >= 600 repeats have been observed in CANVAS patients, while ~100-380 repeats have been observed in controls, and so are not predicted to be pathogenic (PMID: 37450567).",
-        "width":58.0,
-        "OMIM":"614575",
-        "Prevalence":null,
-        "Prevalence_details":"Carrier frequency in European is 0.7-4% and in Chinese Han population is 2.24%; estimated prevalence of 1\/20,000 to 1\/625 (GeneReview). Many cases are likely not diagnosed due to heterogeneous presentation (PMID: 39230846).",
-        "STRipy_gene":"RFC1",
-        "gnomAD_gene":"RFC1",
-        "GeneReviews":"NBK564656",
-        "Mondo":"0044720",
-        "Year":2019.0,
-        "MedGen":"482853",
-        "Orphanet":"504476",
-        "GARD":"17937",
-        "WebSTR_hg38":"4722884; 99101",
-        "WebSTR_hg19":"STR_1036603"
+        "omim":[
+            "614575"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Carrier frequency in European is 0.7-4% and in Chinese Han population is 2.24%; estimated prevalence of 1/20,000 to 1/625 (NBK564656). Many cases are likely not diagnosed due to heterogeneous presentation (PMID: 39230846). Observed in multiple ethnicities (PMID: 38876750); patients diagnosed with European, Chinese Han, and Maori ancestry, as well as found in Japan, Canada, Brazil, the UK, Italy, Germany, and Australia (NBK564656)",
+        "stripy":[
+            "RFC1"
+        ],
+        "gnomad":[
+            "RFC1"
+        ],
+        "genereviews":[
+            "NBK564656"
+        ],
+        "mondo":[
+            "0044720"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "482853"
+        ],
+        "orphanet":[
+            "504476"
+        ],
+        "gard":[
+            "17937"
+        ],
+        "malacard":[
+            "CRB196"
+        ],
+        "webstr_hg38":[
+            "4722884",
+            "99101"
+        ],
+        "webstr_hg19":[
+            "STR_1036603"
+        ],
+        "tr_gnomad":[
+            "TR42349"
+        ],
+        "disease_description":"Sensory disturbances, imbalance, oscillopsia, chronic dry cough, dysarthria and dysphagia (PMID: 38876750); Late-onset ataxia, sensory neuropathy, vestibular areflexia syndrome (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr12",
@@ -3271,61 +5177,88 @@
         "stop_hg19":124018302,
         "start_t2t":123532574,
         "stop_t2t":123532608,
-        "notes_t2t":"(GGC)11.7",
         "id":"OPDM4_RILPL1",
         "disease_id":"OPDM4",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GGC",
-        "pathogenic_motif_reference_orientation":"GGC",
-        "pathogenic_motif_gene_orientation":"CCG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CCG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Oculopharyngodistal myopathy type 4",
         "gene":"RILPL1",
         "flank_motif":null,
         "locus_structure":"(GGC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"5' UTR",
         "location_in_gene":null,
-        "normal":"9-16",
-        "normal_min":9.0,
-        "normal_max":16.0,
-        "intermediate":null,
+        "benign_min":9.0,
+        "benign_max":16.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"139 to 197",
         "pathogenic_min":139.0,
         "pathogenic_max":197.0,
         "ref_copies":11.7,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 18-30 (PMID: 35148830); Range: 10-30 (PMID: 35700120)",
         "age_onset_min":10,
         "age_onset_max":30,
         "typ_age_onset_min":18.0,
         "typ_age_onset_max":30.0,
         "novel":"ref",
-        "Mechanism":"Protein toxic GOF",
-        "Mechanism_detail":"toxic gain-of-function mechanism ",
-        "Mechanism_source":"(Malacard)",
-        "source":"Yu 2022 AJHG",
-        "notes":"toxic poly-glycine protein and\/or toxic RNA gain-of-function effects. AGG and TGG interruptions (PMID: 35148830)",
-        "details":null,
-        "width":35.0,
-        "OMIM":null,
-        "Prevalence":null,
-        "Prevalence_details":"Population dependent. 21.6% of one OPDM cohort (PMID: 35148830)",
-        "STRipy_gene":"RILPL1",
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":"0030712",
-        "Year":2022.0,
-        "MedGen":"1809981",
-        "Orphanet":"98897",
-        "GARD":"12592",
-        "WebSTR_hg38":"5128610; 609239",
-        "WebSTR_hg19":"STR_347096"
+        "mechanism":"Protein toxic GOF",
+        "mechanism_detail":"toxic gain-of-function mechanism (Malacard)",
+        "source":[
+            "Yu 2022 AJHG"
+        ],
+        "details":"toxic poly-glycine protein and/or toxic RNA gain-of-function effects. AGG and TGG interruptions (PMID: 35148830)",
+        "omim":[],
+        "prevalence":null,
+        "prevalence_details":"Population dependent. 21.6% of one OPDM cohort (PMID: 35148830). Typically found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "RILPL1"
+        ],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[
+            "0030712"
+        ],
+        "year":2022.0,
+        "medgen":[
+            "1809981"
+        ],
+        "orphanet":[
+            "98897"
+        ],
+        "gard":[
+            "12592"
+        ],
+        "malacard":[
+            "OCL085"
+        ],
+        "webstr_hg38":[
+            "5128610",
+            "609239"
+        ],
+        "webstr_hg19":[
+            "STR_347096"
+        ],
+        "tr_gnomad":[
+            "TR121403"
+        ],
+        "disease_description":"Ptosis, external ophthalmoplegia, facial weakness, and pharyngeal and distal limb weakness (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr6",
@@ -3335,61 +5268,92 @@
         "stop_hg19":45390529,
         "start_t2t":45257567,
         "stop_t2t":45257611,
-        "notes_t2t":"(GGC)15.0",
         "id":"CCD_RUNX2",
         "disease_id":"CCD",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Cleidocranial dysplasia",
         "gene":"RUNX2",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 3",
-        "normal":"<17",
-        "normal_min":4.0,
-        "normal_max":17.0,
-        "intermediate":null,
+        "benign_min":4.0,
+        "benign_max":17.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">27",
         "pathogenic_min":27.0,
         "pathogenic_max":27.0,
         "ref_copies":15.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth) (GeneReviews)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1038/nature05977) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
         "details":null,
-        "width":42.0,
-        "OMIM":"119600",
-        "Prevalence":null,
-        "Prevalence_details":"All conditions 1\/1,000,000 births (likely underdiagnosed); Utah population frequency 0.12\/10,000",
-        "STRipy_gene":"RUNX2",
-        "gnomAD_gene":"RUNX2",
-        "GeneReviews":"NBK1513",
-        "Mondo":"0007340",
-        "Year":1997.0,
-        "MedGen":"3486",
-        "Orphanet":"1452",
-        "GARD":"6118",
-        "WebSTR_hg38":"5789216",
-        "WebSTR_hg19":null
+        "omim":[
+            "119600"
+        ],
+        "prevalence":null,
+        "prevalence_details":"All conditions 1/1,000,000 births (likely underdiagnosed); Utah population frequency 0.12/10,000. Found in many ethnic groups (Orphanet: 1452)",
+        "stripy":[
+            "RUNX2"
+        ],
+        "gnomad":[
+            "RUNX2"
+        ],
+        "genereviews":[
+            "NBK1513"
+        ],
+        "mondo":[
+            "0007340"
+        ],
+        "year":1997.0,
+        "medgen":[
+            "3486"
+        ],
+        "orphanet":[
+            "1452"
+        ],
+        "gard":[
+            "6118"
+        ],
+        "malacard":[
+            "CLD001"
+        ],
+        "webstr_hg38":[
+            "5789216"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR65117"
+        ],
+        "disease_description":"A condition that primarily affects the development of the bones and teeth. Characteristic features include underdeveloped or absent collarbones (clavicles); dental abnormalities; and delayed closing of the spaces between the skull bones (fontanels). Other features may include decreased bone density (osteopenia), osteoporosis, hearing loss, bone abnormalities of the hands, and recurrent sinus and ear infections. CCD is caused by changes (mutations) in the RUNX2 gene and inheritance is autosomal dominant. It may be inherited from an affected parent or occur due to a new mutation in the RUNX2 gene. Management may include dental procedures, treatment of sinus and ear infections, use of helmets for high-risk activities, and/or surgery for skeletal problems. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr8",
@@ -3399,61 +5363,103 @@
         "stop_hg19":119379157,
         "start_t2t":119495248,
         "stop_t2t":119495353,
-        "notes_t2t":"(AAATA)21.6",
         "id":"FAME1_SAMD12",
         "disease_id":"FAME1",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"TAAAA",
-        "pathogenic_motif_reference_orientation":"TGAAA",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"AAAAA,TAAAC,TAACA,TACAA,TACAC",
-        "unknown_motif_gene_orientation":"TTTTT,AGTTT,ATGTT,ATTGT,AGTGT",
+        "reference_motif_reference_orientation":[
+            "TAAAA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TGAAA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "AAAAA",
+            "TAAAC",
+            "TAACA",
+            "TACAA",
+            "TACAC"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT",
+            "AGTTT",
+            "ATGTT",
+            "ATTGT",
+            "AGTGT"
+        ],
         "disease":"Familial adult myoclonic epilepsy type 1",
         "gene":"SAMD12",
         "flank_motif":null,
         "locus_structure":"(TAAAA)*(TGAAA)*(TAAAA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":"Intron 4\/4",
-        "normal":"0",
-        "normal_min":0.0,
-        "normal_max":0.0,
-        "intermediate":null,
+        "location_in_gene":"Intron 4/4",
+        "benign_min":0.0,
+        "benign_max":0.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"105\u20133680",
         "pathogenic_min":105.0,
         "pathogenic_max":3680.0,
         "ref_copies":21.6,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 21-39 (PMID: 29939203); Range: 12 (PMID: 29939203) - 68 (PMID: 29507423)",
         "age_onset_min":12,
         "age_onset_max":68,
         "typ_age_onset_min":21.0,
         "typ_age_onset_max":39.0,
         "novel":"novel",
-        "Mechanism":"RNA toxicity proposed",
-        "Mechanism_detail":"RNA molecules",
-        "Mechanism_source":"(OMIM)",
-        "source":"Ishiura 2018. https:\/\/movementdisorders.onlinelibrary.wiley.com\/doi\/full\/10.1002\/mds.27832",
-        "notes":"Novel, pathogenic alleles include expansions of TTTTAn + TTTCAn, but only the TTTCA is specific to affected individuals, check reference and pathogenic sites with Stranger. TTTCA within TTTTA repeat region",
-        "details":null,
-        "width":105.0,
-        "OMIM":"601068",
-        "Prevalence":null,
-        "Prevalence_details":"FAME overall is 1\/35,000 in Japan",
-        "STRipy_gene":"SAMD12",
-        "gnomAD_gene":"SAMD12",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010985",
-        "Year":2018.0,
-        "MedGen":"371424",
-        "Orphanet":"86814",
-        "GARD":"18082",
-        "WebSTR_hg38":"1087693",
-        "WebSTR_hg19":null
+        "mechanism":"RNA toxicity proposed",
+        "mechanism_detail":"RNA molecules (OMIM)",
+        "source":[
+            "Ishiura 2018. https://movementdisorders.onlinelibrary.wiley.com/doi/full/10.1002/mds.27832"
+        ],
+        "details":"Novel, pathogenic alleles include expansions of TTTTAn + TTTCAn, but only the TTTCA is specific to affected individuals. TTTCA within TTTTA repeat region",
+        "omim":[
+            "601068"
+        ],
+        "prevalence":null,
+        "prevalence_details":"FAME overall is 1/35,000 in Japan. Typically found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "SAMD12"
+        ],
+        "gnomad":[
+            "SAMD12"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010985"
+        ],
+        "year":2018.0,
+        "medgen":[
+            "371424"
+        ],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "18082"
+        ],
+        "malacard":[
+            "EPL201"
+        ],
+        "webstr_hg38":[
+            "1087693"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR89226"
+        ],
+        "disease_description":"Cortical tremor, seizures with generalised motor (tonic-clonic) onset (PMID: 38876750); Adult-onset cortical myoclonus, with seizures in up to a half of patients (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -3463,61 +5469,92 @@
         "stop_hg19":139586526,
         "start_t2t":138816205,
         "stop_t2t":138816239,
-        "notes_t2t":"(GCGGCAGCGGCGGCGG)1.9",
         "id":"XLMR_SOX3",
         "disease_id":"XLMR",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"NGC",
-        "pathogenic_motif_reference_orientation":"NGC",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
-        "disease":"X-linked panhypopituitarism ; X-linked mental retardation with isolated growth hormone    ",
+        "reference_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "NGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
+        "disease":"X-linked panhypopituitarism ; X-linked mental retardation with isolated growth hormone",
         "gene":"SOX3",
         "flank_motif":null,
         "locus_structure":"(NGC)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"< 15",
-        "normal_min":15.0,
-        "normal_max":15.0,
-        "intermediate":null,
+        "benign_min":15.0,
+        "benign_max":15.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"> 22",
         "pathogenic_min":22.0,
         "pathogenic_max":26.0,
         "ref_copies":15.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 0-3 (PMID: 19654509, PMID: 21289259; small sample size); Range: 0-9 (PMID: 19654509) ",
         "age_onset_min":0,
         "age_onset_max":9,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
         "details":null,
-        "width":45.0,
-        "OMIM":"300123",
-        "Prevalence":null,
-        "Prevalence_details":"3 families.",
-        "STRipy_gene":"SOX3",
-        "gnomAD_gene":"SOX3",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010252",
-        "Year":2002.0,
-        "MedGen":"394771",
-        "Orphanet":"67045",
-        "GARD":null,
-        "WebSTR_hg38":null,
-        "WebSTR_hg19":"STR_1597784"
+        "omim":[
+            "300123",
+            "312000"
+        ],
+        "prevalence":null,
+        "prevalence_details":"3 families reported, however they were distributed across the world (OMIM: 300123)",
+        "stripy":[
+            "SOX3"
+        ],
+        "gnomad":[
+            "SOX3"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010252"
+        ],
+        "year":2002.0,
+        "medgen":[
+            "394771"
+        ],
+        "orphanet":[
+            "67045"
+        ],
+        "gard":[],
+        "malacard":[
+            "PNH005",
+            "INT405"
+        ],
+        "webstr_hg38":[],
+        "webstr_hg19":[
+            "STR_1597784"
+        ],
+        "tr_gnomad":[
+            "TR173479"
+        ],
+        "disease_description":"X-linked isolated growth hormone deficiency (GHD) or combined pituitary hormone deficiency (CPHD) patients with or without [intellectual disability] (PMID: 24346842)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr2",
@@ -3527,61 +5564,212 @@
         "stop_hg19":96862859,
         "start_t2t":96703675,
         "stop_t2t":96703729,
-        "notes_t2t":"(AAAAT)11.6",
         "id":"FAME2_STARD7",
         "disease_id":"FAME2",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"AAAAT",
-        "pathogenic_motif_reference_orientation":"AAATG",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"AAAAA,AAAAC,AAACC,AAACG,AAACT,AACTC,AACTG,AATAC,AATAG,ATAAC",
-        "unknown_motif_gene_orientation":"TTTTT,GTTTT,GGTTT,CGTTT,AGTTT,AGTTG,AGTTC,ATTGT,ATTCT,ATGTT",
+        "reference_motif_reference_orientation":[
+            "AAAAT"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "AAATG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "AAAAA",
+            "AAAAC",
+            "AAACC",
+            "AAACG",
+            "AAACT",
+            "AACTC",
+            "AACTG",
+            "AATAC",
+            "AATAG",
+            "ATAAC"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT",
+            "GTTTT",
+            "GGTTT",
+            "CGTTT",
+            "AGTTT",
+            "AGTTG",
+            "AGTTC",
+            "ATTGT",
+            "ATTCT",
+            "ATGTT"
+        ],
         "disease":"Familial adult myoclonic epilepsy 2",
         "gene":"STARD7",
         "flank_motif":null,
         "locus_structure":"(AAATG)*(AAAAT)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":null,
-        "normal":"0",
-        "normal_min":0.0,
-        "normal_max":0.0,
-        "intermediate":null,
+        "location_in_gene":"Intron 1",
+        "benign_min":0.0,
+        "benign_max":0.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">274",
         "pathogenic_min":274.0,
         "pathogenic_max":274.0,
         "ref_copies":11.6,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 12-30; Range: 4-60 (PMID: 31664034)",
         "age_onset_min":4,
         "age_onset_max":60,
         "typ_age_onset_min":12.0,
         "typ_age_onset_max":30.0,
         "novel":"novel",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA toxicity ",
-        "Mechanism_source":"(10.1038\/s41467-019-12671-y)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2",
-        "notes":null,
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA toxicity (10.1038/s41467-019-12671-y)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2"
+        ],
         "details":null,
-        "width":54.0,
-        "OMIM":"607876",
-        "Prevalence":null,
-        "Prevalence_details":"FAME overall is 1\/35,000 in Japan",
-        "STRipy_gene":"STARD7",
-        "gnomAD_gene":"STARD7",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0011930",
-        "Year":2019.0,
-        "MedGen":"375031",
-        "Orphanet":"86814",
-        "GARD":"18083",
-        "WebSTR_hg38":"286156",
-        "WebSTR_hg19":"STR_754470"
+        "omim":[
+            "607876"
+        ],
+        "prevalence":null,
+        "prevalence_details":"FAME overall is 1/35,000 in Japan. This repeat expansion is typically found in individuals of European ancestry (PMID: 38876750)",
+        "stripy":[
+            "STARD7"
+        ],
+        "gnomad":[
+            "STARD7"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0011930"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "375031"
+        ],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "18083"
+        ],
+        "malacard":[
+            "EPL203"
+        ],
+        "webstr_hg38":[
+            "286156"
+        ],
+        "webstr_hg19":[
+            "STR_754470"
+        ],
+        "tr_gnomad":[
+            "TR19329"
+        ],
+        "disease_description":"Finger, hand tremor with later-onset myoclonus and generalised tonic-clonic seizures (PMID: 39349043)",
+        "locus_tags":[],
+        "disease_tags":[]
+    },
+    {
+        "chrom":"chrX",
+        "start_hg38":71453055,
+        "stop_hg38":71453129,
+        "start_hg19":70672905,
+        "stop_hg19":70672979,
+        "start_t2t":69887154,
+        "stop_t2t":69887228,
+        "id":"XDP_TAF1",
+        "disease_id":"XDP",
+        "gene_strand":"+",
+        "reference_motif_reference_orientation":[
+            "AGAGGG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "AGAGGG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGAGGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
+        "disease":"X-linked dystonia-parkinsonism (XDP) a.k.a. Dystonia 3, torsion, X-linked (DYT3)",
+        "gene":"TAF1",
+        "flank_motif":null,
+        "locus_structure":"(AGAGGG)*",
+        "inheritance":[
+            "XR"
+        ],
+        "type":"Intronic",
+        "location_in_gene":"Intron 32",
+        "benign_min":null,
+        "benign_max":null,
+        "intermediate_min":null,
+        "intermediate_max":null,
+        "pathogenic_min":35.0,
+        "pathogenic_max":52.0,
+        "ref_copies":4.0,
+        "motif_len":6,
+        "age_onset":"Average age of onset for XDP is 39.7 years in males, 52 years in females, range 12-79 years. ~99% of cases are male (PMID: 29229810, PMID: 38876750, PMID: 15596620)",
+        "age_onset_min":12,
+        "age_onset_max":79,
+        "typ_age_onset_min":39.7,
+        "typ_age_onset_max":39.7,
+        "novel":null,
+        "mechanism":null,
+        "mechanism_detail":"Altered splicing with intron retention, haploinsufficiency [pmid:38876750]",
+        "source":[
+            "https://doi.org/10.1042/ETLS20230074",
+            "https://doi.org/10.1086/512129",
+            "https://doi.org/10.1073/pnas.1712526114",
+            "https://doi.org/10.1093/braincomms/fcab253",
+            "https://doi.org/10.1016/j.cell.2018.02.011",
+            "https://doi.org/10.1016/s1474-4422(24)00167-4"
+        ],
+        "details":null,
+        "omim":[
+            "314250"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Philippines overall 0.34:100,000. Panay Islands 5.24:100,000. Capiz province 18.9:100,000. To date, all known cases to date are of Filipino descent (PMID: 38876750)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[
+            "NBK1489"
+        ],
+        "mondo":[
+            "0010747"
+        ],
+        "year":2017.0,
+        "medgen":[
+            "326820"
+        ],
+        "orphanet":[
+            "53351"
+        ],
+        "gard":[
+            "10533"
+        ],
+        "malacard":[
+            "DYS064"
+        ],
+        "webstr_hg38":[
+            "861907"
+        ],
+        "webstr_hg19":[
+            "STR_1564408"
+        ],
+        "tr_gnomad":[
+            "TR592600"
+        ],
+        "disease_description":"X-linked dystonia-parkinsonism (XDP) associated with antisense insertion of a SINE-VNTR-Alu (SVA)-type retrotransposon within an intron of TAF1. Clinical features include focal and generalised dystonia, parkinsonism, cognitive dysfunction. XX individuals who are heterozygous carriers usually do not develop the full syndrome, although some patients have non-progressive focal dystonia with parkinsonism. Disease severity is associated with number of hexanucleotide repeats within the SVA. (Adapted from PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr6",
@@ -3591,61 +5779,95 @@
         "stop_hg19":170871105,
         "start_t2t":171935459,
         "stop_t2t":171935569,
-        "notes_t2t":"(GCA)37.0",
         "id":"SCA17_TBP",
         "disease_id":"SCA17",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCA",
-        "pathogenic_motif_reference_orientation":"GCA",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar ataxia type 17",
         "gene":"TBP",
         "flank_motif":null,
         "locus_structure":"(GCA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 3",
-        "normal":"25\u201340",
-        "normal_min":25.0,
-        "normal_max":40.0,
-        "intermediate":"41\u201348",
+        "benign_min":25.0,
+        "benign_max":40.0,
         "intermediate_min":41.0,
         "intermediate_max":48.0,
-        "pathogenic":"49 to 66",
         "pathogenic_min":49.0,
         "pathogenic_max":66.0,
         "ref_copies":37.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 19-48; Range: 3-62 [has second variant to delay onset] (OMIM)",
         "age_onset_min":3,
         "age_onset_max":62,
         "typ_age_onset_min":19.0,
         "typ_age_onset_max":48.0,
         "novel":"ref",
-        "Mechanism":"Polyglutamine ",
-        "Mechanism_detail":"Polyglutamine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nrg.2017.115) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Hannan 2018, Mirkin 2007, GeneReviews NBK1438",
-        "notes":"Parkinson disease,late-onset. Interruptions Seen: CAA (PMID: 35245110)",
-        "details":null,
-        "width":110.0,
-        "OMIM":"607136",
-        "Prevalence":"0.2\/100000",
-        "Prevalence_details":"Unknown (global), <100 families, 0.47:1,000,000 (Japanese), 0.16\/100,000 (England) (GeneReview); Tang et al., 2017: 0.2\/100,000",
-        "STRipy_gene":"TBP",
-        "gnomAD_gene":"TBP",
-        "GeneReviews":"NBK1438",
-        "Mondo":"0011781",
-        "Year":1999.0,
-        "MedGen":"337637",
-        "Orphanet":"98759",
-        "GARD":"10469",
-        "WebSTR_hg38":"83566",
-        "WebSTR_hg19":null
+        "mechanism":"Polyglutamine",
+        "mechanism_detail":"Polyglutamine (doi.org/10.1038/nrg.2017.115) (doi.org/10.1007/s11604-022-01343-5)",
+        "source":[
+            "Hannan 2018",
+            "Mirkin 2007",
+            "GeneReviews NBK1438"
+        ],
+        "details":"Interruptions Seen: CAA (PMID: 35245110)",
+        "omim":[
+            "607136"
+        ],
+        "prevalence":"0.2/100000",
+        "prevalence_details":"Unknown (global), <100 families, 0.47:1,000,000 (Japanese), 0.16/100,000 (England) (GeneReview); Tang et al., 2017: 0.2/100,000. Found across ethnicities/ancestries, with population-dependent prevalence (NBK1438)",
+        "stripy":[
+            "TBP"
+        ],
+        "gnomad":[
+            "TBP"
+        ],
+        "genereviews":[
+            "NBK1438"
+        ],
+        "mondo":[
+            "0011781"
+        ],
+        "year":1999.0,
+        "medgen":[
+            "337637"
+        ],
+        "orphanet":[
+            "98759"
+        ],
+        "gard":[
+            "10469"
+        ],
+        "malacard":[
+            "SPN296"
+        ],
+        "webstr_hg38":[
+            "83566"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR72502"
+        ],
+        "disease_description":"A rare subtype of type I autosomal dominant cerebellar ataxia (ADCA type I). It is characterized by a variable clinical picture which can include dementia, psychiatric disorders, parkinsonism, dystonia, chorea, spasticity, and epilepsy. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr22",
@@ -3655,61 +5877,94 @@
         "stop_hg19":19754330,
         "start_t2t":20143615,
         "stop_t2t":20143660,
-        "notes_t2t":null,
         "id":"TOF_TBX1",
         "disease_id":"TOF",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Tetralogy of Fallot",
         "gene":"TBX1",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
-        "location_in_gene":null,
-        "normal":"<15",
-        "normal_min":15.0,
-        "normal_max":15.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 9",
+        "benign_min":15.0,
+        "benign_max":15.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">25",
         "pathogenic_min":25.0,
         "pathogenic_max":25.0,
         "ref_copies":15.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(OMIM)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine (OMIM)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
         "details":null,
-        "width":45.0,
-        "OMIM":"187500",
-        "Prevalence":null,
-        "Prevalence_details":"1 individual with STR mutation (GeneReview)",
-        "STRipy_gene":"TBX1",
-        "gnomAD_gene":"TBX1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0008542",
-        "Year":null,
-        "MedGen":"21498",
-        "Orphanet":"3303",
-        "GARD":"2245",
-        "WebSTR_hg38":"4900984",
-        "WebSTR_hg19":"STR_889797"
+        "omim":[
+            "187500"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Found in one Turkish individual (GeneReview NBK535148)",
+        "stripy":[
+            "TBX1"
+        ],
+        "gnomad":[
+            "TBX1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0008542"
+        ],
+        "year":null,
+        "medgen":[
+            "21498"
+        ],
+        "orphanet":[
+            "3303"
+        ],
+        "gard":[
+            "2245"
+        ],
+        "malacard":[
+            "TTR001"
+        ],
+        "webstr_hg38":[
+            "4900984"
+        ],
+        "webstr_hg19":[
+            "STR_889797"
+        ],
+        "tr_gnomad":[
+            "TR163862"
+        ],
+        "disease_description":"Tetralogy of Fallot is a congenital cardiac malformation that consists of an interventricular communication, also known as a ventricular septal defect, obstruction of the right ventricular outflow tract, override of the ventricular septum by the aortic root, and right ventricular hypertrophy. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr18",
@@ -3719,61 +5974,94 @@
         "stop_hg19":53253458,
         "start_t2t":55789234,
         "stop_t2t":55789288,
-        "notes_t2t":"(AGC)18.3",
         "id":"FECD3_TCF4",
         "disease_id":"FECD3",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"CAG",
-        "pathogenic_motif_reference_orientation":"CAG",
-        "pathogenic_motif_gene_orientation":"CTG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CTG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Fuchs endothelial corneal dystrophy 3",
         "gene":"TCF4",
         "flank_motif":null,
         "locus_structure":"(CAG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
         "location_in_gene":"Intron 1",
-        "normal":"10 - 40",
-        "normal_min":10.0,
-        "normal_max":40.0,
-        "intermediate":null,
+        "benign_min":10.0,
+        "benign_max":40.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">50",
         "pathogenic_min":50.0,
         "pathogenic_max":150.0,
         "ref_copies":25.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 40-59 (PMID: 1676829); Range: 32 (PMID: 21245398) - 70 (PMID: 25168903)",
         "age_onset_min":32,
         "age_onset_max":70,
         "typ_age_onset_min":40.0,
         "typ_age_onset_max":59.0,
         "novel":"ref",
-        "Mechanism":"RNA toxicity proposed",
-        "Mechanism_detail":"\"sequestration of MBNL1 in RNA foci, similar to the mechanism underlying myotonic dystrophy-1 \"",
-        "Mechanism_source":"(10.1074\/jbc.M114.621607)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
-        "details":"Penetrance is <100%; reduced penetrance has been reported in individuals with >80 CTG repeats [Wieben et al 2014]. Predominantly in women (~75%) (PMID: 16769829). \u201cAlthough studies on the prevalence of FECD worldwide are limited, the disorder is thought to be more common in Eurasian populations, with its corneal manifestations documented in 11% of females and 7% of males in Reykjavik, Iceland,3 8.5 % of Singapore Chinese,4 and 5.5% of Japanese.4 (PMID: 25722209)  ",
-        "width":72.0,
-        "OMIM":"613267",
-        "Prevalence":"4.5\/100",
-        "Prevalence_details":"~4\/100 (over 40) (OMIM); 5\/100 (PMID: 20825314)",
-        "STRipy_gene":"TCF4",
-        "gnomAD_gene":"TCF4",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0013203",
-        "Year":2015.0,
-        "MedGen":"442479",
-        "Orphanet":"98974",
-        "GARD":"10018",
-        "WebSTR_hg38":"6247607; 463325",
-        "WebSTR_hg19":null
+        "mechanism":"RNA toxicity proposed",
+        "mechanism_detail":"sequestration of MBNL1 in RNA foci, similar to the mechanism underlying myotonic dystrophy-1 (10.1074/jbc.M114.621607)",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
+        "details":"Penetrance is <100%; reduced penetrance has been reported in individuals with >80 CTG repeats [Wieben et al 2014]. Predominantly in women (~75%) (PMID: 16769829). Although studies on the prevalence of FECD worldwide are limited, the disorder is thought to be more common in Eurasian populations (PMID: 26401622), with its corneal manifestations documented in 11% of females and 7% of males in Reykjavik, Iceland, 8.5 % of Singapore Chinese, and 5.5% of Japanese. (PMID: 25722209). Uncommon/rare in Saudi Arabia, Singaporean Chinese, and Japan (Orphanet: 98974)",
+        "omim":[
+            "613267"
+        ],
+        "prevalence":"4.5/100",
+        "prevalence_details":"~4/100 (over 40) (OMIM); 5/100 (PMID: 20825314)",
+        "stripy":[
+            "TCF4"
+        ],
+        "gnomad":[
+            "TCF4"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0013203"
+        ],
+        "year":2015.0,
+        "medgen":[
+            "442479"
+        ],
+        "orphanet":[
+            "98974"
+        ],
+        "gard":[
+            "10018"
+        ],
+        "malacard":[
+            "FCH001",
+            "CRN120"
+        ],
+        "webstr_hg38":[
+            "6247607",
+            "463325"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR151784"
+        ],
+        "disease_description":"Late-onset Fuchs endothelial corneal dystrophy (FECD) is a degenerative disorder ... distinguished from other corneal disorders by the progressive formation of guttae (OMIM: 613267)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr16",
@@ -3783,61 +6071,83 @@
         "stop_hg19":67876853,
         "start_t2t":73638637,
         "stop_t2t":73638724,
-        "notes_t2t":null,
         "id":"SCA_THAP11",
         "disease_id":"SCA",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"CAG",
-        "pathogenic_motif_reference_orientation":"CAG",
-        "pathogenic_motif_gene_orientation":"AGC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "CAG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar ataxia",
         "gene":"THAP11",
         "flank_motif":null,
         "locus_structure":"(CAG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"20-38",
-        "normal_min":20.0,
-        "normal_max":38.0,
-        "intermediate":null,
+        "benign_min":20.0,
+        "benign_max":38.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"45-100",
         "pathogenic_min":45.0,
         "pathogenic_max":100.0,
         "ref_copies":29.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Typical: 8-40 (small sample size); Range: 4-51 (PMID: 37148549)",
         "age_onset_min":4,
         "age_onset_max":51,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"PolyQ toxicity",
-        "Mechanism_detail":null,
-        "Mechanism_source":"https:\/\/doi.org\/10.1002\/mds.29412",
-        "source":"https:\/\/doi.org\/10.1002\/mds.29412, https:\/\/doi.org\/10.1042\/ETLS20230018",
-        "notes":"CAA interruptions can reduce toxicity (PMID: 37148549)",
-        "details":"Expansion found in affected individuals from 2 families and not in 500 controls. Longer alleles were associated with earlier age of onset. For example, an individual with 100 repeats had age of onset at 4 years.",
-        "width":null,
-        "OMIM":null,
-        "Prevalence":null,
-        "Prevalence_details":"Unknown",
-        "STRipy_gene":null,
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":null,
-        "Year":2023.0,
-        "MedGen":"431598",
-        "Orphanet":null,
-        "GARD":"10748",
-        "WebSTR_hg38":"814002; 5973136",
-        "WebSTR_hg19":"STR_540982"
+        "mechanism":"PolyQ toxicity",
+        "mechanism_detail":"PolyQ toxicity (https://doi.org/10.1002/mds.29412)",
+        "source":[
+            "https://doi.org/10.1002/mds.29412",
+            "https://doi.org/10.1042/ETLS20230018"
+        ],
+        "details":"Expansion found in affected individuals from 2 families and not in 500 controls. Longer alleles were associated with earlier age of onset. For example, an individual with 100 repeats had age of onset at 4 years. CAA interruptions can reduce toxicity (PMID: 37148549)",
+        "omim":[],
+        "prevalence":null,
+        "prevalence_details":"Has been observed in Chinese families (PMID: 37148549; PMID: 24677642)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[],
+        "year":2023.0,
+        "medgen":[
+            "431598"
+        ],
+        "orphanet":[],
+        "gard":[
+            "10748"
+        ],
+        "malacard":[],
+        "webstr_hg38":[
+            "814002",
+            "5973136"
+        ],
+        "webstr_hg19":[
+            "STR_540982"
+        ],
+        "tr_gnomad":[
+            "TR142069"
+        ],
+        "disease_description":"THAP11-caused SCA involves symptoms including gait ataxia, dysarthia, dysphagia, slow saccades, ptosis, and/or nystagmus (PMID: 37148549)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr16",
@@ -3847,61 +6157,98 @@
         "stop_hg19":24624853,
         "start_t2t":24890367,
         "stop_t2t":24890430,
-        "notes_t2t":"(ATTTT)12.8",
         "id":"FAME6_TNRC6A",
         "disease_id":"FAME6",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"TTTTA",
-        "pathogenic_motif_reference_orientation":"TTTCA",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"TTTTT",
-        "unknown_motif_gene_orientation":"TTTTT",
+        "reference_motif_reference_orientation":[
+            "TTTTA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TTTCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "TTTTT"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT"
+        ],
         "disease":"Familial adult myoclonic epilepsy type 6",
         "gene":"TNRC6A",
         "flank_motif":null,
         "locus_structure":"(TTTTA)*(TTTCA)*(TTTTA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":null,
-        "normal":"0",
-        "normal_min":0.0,
-        "normal_max":0.0,
-        "intermediate":null,
+        "location_in_gene":"Exon 1",
+        "benign_min":0.0,
+        "benign_max":0.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">1100, >=10, 29",
         "pathogenic_min":1100.0,
         "pathogenic_max":1100.0,
         "ref_copies":18.8,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"Limited clinical details from one family, \"early 20s to 70s\"",
         "age_onset_min":23,
         "age_onset_max":74,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"novel",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA toxicity hypothesized",
-        "Mechanism_source":"(10.1038\/s41588-018-0067-2)",
-        "source":"Ishiura 2018; gnomad v3.1.2, 29507423 (Pubmed), https:\/\/doi.org\/10.1038\/s41597-020-00633-9, https:\/\/stripy.org\/database\/TNRC6A",
-        "notes":"Novel, reported pathogenic alleles: (TTTTA)22 (TTTCA)exp (TTTTA)exp, but only the TTTCA is specific to affected individuals, Alu-associated repeat. Non-pathogenic reference TTTTA repeat was expanded in nine healthy subjects 40-120 repeats and in two individuals potentially even longer (Ishiura et al., 2018).",
-        "details":null,
-        "width":93.0,
-        "OMIM":"618074",
-        "Prevalence":null,
-        "Prevalence_details":"FAME overall is 1\/35,000 in Japan",
-        "STRipy_gene":"TNRC6A",
-        "gnomAD_gene":"TNRC6A",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0054846",
-        "Year":2018.0,
-        "MedGen":"1648448",
-        "Orphanet":"86814",
-        "GARD":"16758",
-        "WebSTR_hg38":"5951520",
-        "WebSTR_hg19":"STR_519979"
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA toxicity hypothesized (10.1038/s41588-018-0067-2)",
+        "source":[
+            "Ishiura 2018",
+            "gnomad v3.1.2, 29507423 (Pubmed), https://doi.org/10.1038/s41597-020-00633-9, https://stripy.org/database/TNRC6A"
+        ],
+        "details":"Novel, reported pathogenic alleles: (TTTTA)22 (TTTCA)exp (TTTTA)exp, but only the TTTCA is specific to affected individuals, Alu-associated repeat. Non-pathogenic reference TTTTA repeat was expanded in nine healthy subjects 40-120 repeats and in two individuals potentially even longer (Ishiura et al., 2018).",
+        "omim":[
+            "618074"
+        ],
+        "prevalence":null,
+        "prevalence_details":"FAME overall is 1/35,000 in Japan. This repeat expansion is typically found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "TNRC6A"
+        ],
+        "gnomad":[
+            "TNRC6A"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0054846"
+        ],
+        "year":2018.0,
+        "medgen":[
+            "1648448"
+        ],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "16758"
+        ],
+        "malacard":[
+            "EPL227"
+        ],
+        "webstr_hg38":[
+            "5951520"
+        ],
+        "webstr_hg19":[
+            "STR_519979"
+        ],
+        "tr_gnomad":[
+            "TR139999"
+        ],
+        "disease_description":"Cortical tremor, seizures with generalised motor (tonic-clonic) onset (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr1",
@@ -3911,61 +6258,87 @@
         "stop_hg19":1371198,
         "start_t2t":870158,
         "stop_t2t":870178,
-        "notes_t2t":null,
         "id":"HMNR7_VWA1",
         "disease_id":"HMNR7",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GGCGCGGAGC",
-        "pathogenic_motif_reference_orientation":"GGCGCGGAGC",
-        "pathogenic_motif_gene_orientation":"AGCGGCGCGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GGCGCGGAGC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GGCGCGGAGC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "AGCGGCGCGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Neuronopathy, distal hereditary motor, autosomal recessive 7",
         "gene":"VWA1",
         "flank_motif":null,
         "locus_structure":"(GGCGCGGAGC)*",
-        "Inheritance":"AR",
+        "inheritance":[
+            "AR"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 1",
-        "normal":"2",
-        "normal_min":2.0,
-        "normal_max":2.0,
-        "intermediate":null,
+        "benign_min":2.0,
+        "benign_max":2.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"Any deviation from 2",
         "pathogenic_min":1.0,
         "pathogenic_max":3.0,
         "ref_copies":null,
-        "repeatunitlen":10,
+        "motif_len":10,
         "age_onset":"Typical: 1-3 (PMID: 33559681); Range: 0-10 (OMIM)",
         "age_onset_min":0,
         "age_onset_max":10,
         "typ_age_onset_min":1.0,
         "typ_age_onset_max":3.0,
         "novel":null,
-        "Mechanism":"LoF",
-        "Mechanism_detail":null,
-        "Mechanism_source":"PMID: 38467784",
-        "source":null,
-        "notes":null,
+        "mechanism":"LoF",
+        "mechanism_detail":"Loss of function [pmid:38467784]",
+        "source":[],
         "details":"Any deviation from 2 motifs is thought to be pathogenic",
-        "width":null,
-        "OMIM":"619216",
-        "Prevalence":null,
-        "Prevalence_details":"Biallelic variants found in 0.01% of 100 KGP participants; enriched in those with motor disease. 80% of VWA1 pathogenic variants are expansions\/contractions (GeneReview)",
-        "STRipy_gene":null,
-        "gnomAD_gene":"VWA1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0030977",
-        "Year":null,
-        "MedGen":"1786836",
-        "Orphanet":"314485",
-        "GARD":"18444",
-        "WebSTR_hg38":"1099767",
-        "WebSTR_hg19":null
+        "omim":[
+            "619216"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Biallelic variants found in 0.01% of 100 KGP participants; enriched in those with motor disease. 80% of VWA1 pathogenic variants are expansions/contractions (GeneReview). The repeat expansion was found in several ethnicities; founder mutation 7,000 years prior (PMID: 33559681)",
+        "stripy":[],
+        "gnomad":[
+            "VWA1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0030977"
+        ],
+        "year":null,
+        "medgen":[
+            "1786836"
+        ],
+        "orphanet":[
+            "314485"
+        ],
+        "gard":[
+            "18444"
+        ],
+        "malacard":[
+            "NRN074"
+        ],
+        "webstr_hg38":[
+            "1099767"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR32"
+        ],
+        "disease_description":"Autosomal recessive distal hereditary motor neuronopathy-7 (HMNR7) is characterized by onset of lower leg weakness in the first decade. Affected individuals have difficulty climbing stairs and problems standing on the heels... Most patients have foot deformities, and some may have leg muscle atrophy. The disorder is slowly progressive and often involves the upper limbs (OMIM: 619216)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr16",
@@ -3975,61 +6348,93 @@
         "stop_hg19":17564779,
         "start_t2t":17477910,
         "stop_t2t":17478013,
-        "notes_t2t":"(GCC)34.7",
         "id":"DBQD2_XYLT1",
         "disease_id":"DBQD2, BSS",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GCC",
-        "pathogenic_motif_reference_orientation":"GCC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
-        "disease":"Baratela-Scott Syndrome\/Desbuquois dysplasia 2",
+        "reference_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
+        "disease":"Baratela-Scott Syndrome/Desbuquois dysplasia 2",
         "gene":"XYLT1",
         "flank_motif":null,
         "locus_structure":"(GCC)*",
-        "Inheritance":"AR",
-        "type":"Promoter",
+        "inheritance":[
+            "AR"
+        ],
+        "type":"5' UTR",
         "location_in_gene":"Intron 1",
-        "normal":"<20",
-        "normal_min":0.0,
-        "normal_max":20.0,
-        "intermediate":null,
+        "benign_min":0.0,
+        "benign_max":20.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">72",
         "pathogenic_min":72.0,
         "pathogenic_max":110.0,
         "ref_copies":0.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0 (birth)",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":0.0,
         "typ_age_onset_max":0.0,
         "novel":"ref",
-        "Mechanism":"Methylation",
-        "Mechanism_detail":"Methylation",
-        "Mechanism_source":"(doi.org\/10.1016\/j.ajhg.2018.11.005)",
-        "source":"LaCroix 2019, gnomad v3.1.2, 30554721",
-        "notes":"Repeat is within a sequencing missing from hg38",
-        "details":null,
-        "width":1.0,
-        "OMIM":"615777",
-        "Prevalence":null,
-        "Prevalence_details":"<1 \/ 1,000,000 births (orphanet); \u00bd of DBQD variants (GeneReview). <50 DBQD cases",
-        "STRipy_gene":"XYLT1",
-        "gnomAD_gene":"XYLT1",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0014343",
-        "Year":2019.0,
-        "MedGen":"862731",
-        "Orphanet":"1425",
-        "GARD":"16466",
-        "WebSTR_hg38":"793606",
-        "WebSTR_hg19":null
+        "mechanism":"Methylation",
+        "mechanism_detail":"Methylation (doi.org/10.1016/j.ajhg.2018.11.005)",
+        "source":[
+            "LaCroix 2019",
+            "gnomad v3.1.2",
+            "30554721"
+        ],
+        "details":"Repeat is within a 238bp sequence which is missing from hg38 but present in T2T-CHM13",
+        "omim":[
+            "615777"
+        ],
+        "prevalence":null,
+        "prevalence_details":"<1 / 1,000,000 births (orphanet); half of DBQD variants (GeneReview). <50 DBQD cases. Has been found in Belgian, Emirati families",
+        "stripy":[
+            "XYLT1"
+        ],
+        "gnomad":[
+            "XYLT1"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0014343"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "862731"
+        ],
+        "orphanet":[
+            "1425"
+        ],
+        "gard":[
+            "16466"
+        ],
+        "malacard":[
+            "DSB005"
+        ],
+        "webstr_hg38":[
+            "793606"
+        ],
+        "webstr_hg19":[],
+        "tr_gnomad":[
+            "TR139509"
+        ],
+        "disease_description":"Desbuquois dysplasia, which belongs to the multiple dislocation group of disorders, is characterized by dislocations of large joints, severe pre- and postnatal growth retardation, joint laxity, and flat face with prominent eyes. Radiologic features include short long bones with an exaggerated trochanter that gives a 'monkey wrench' appearance to the proximal femur, and advanced carpal and tarsal ossification (PMID: 24581741)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr3",
@@ -4039,61 +6444,100 @@
         "stop_hg19":183430010,
         "start_t2t":186521657,
         "stop_t2t":186521706,
-        "notes_t2t":"(ATTTT)10.0",
         "id":"FAME4_YEATS2",
         "disease_id":"FAME4",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"TTTTA",
-        "pathogenic_motif_reference_orientation":"TTTCA",
-        "pathogenic_motif_gene_orientation":"ATTTC",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":"TTTTT,TGTTA",
-        "unknown_motif_gene_orientation":"TTTTT,ATGTT",
+        "reference_motif_reference_orientation":[
+            "TTTTA"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "TTTCA"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "ATTTC"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[
+            "TTTTT",
+            "TGTTA"
+        ],
+        "unknown_motif_gene_orientation":[
+            "TTTTT",
+            "ATGTT"
+        ],
         "disease":"Familial adult myoclonic epilepsy 4",
         "gene":"YEATS2",
         "flank_motif":null,
         "locus_structure":"(TTTTA)*(TTTCA)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":null,
-        "normal":"0",
-        "normal_min":0.0,
-        "normal_max":0.0,
-        "intermediate":null,
+        "location_in_gene":"Intron 1",
+        "benign_min":0.0,
+        "benign_max":0.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">1000",
         "pathogenic_min":1000.0,
         "pathogenic_max":1000.0,
         "ref_copies":10.0,
-        "repeatunitlen":5,
+        "motif_len":5,
         "age_onset":"Typical: 20-25 (PMID: 22713812); Range: 10-33 (PMID: 31539032)",
         "age_onset_min":10,
         "age_onset_max":33,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"novel",
-        "Mechanism":"RNA toxicity",
-        "Mechanism_detail":"RNA toxicity hypothesized",
-        "Mechanism_source":"(10.1093\/brain\/awz267)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2",
-        "notes":null,
+        "mechanism":"RNA toxicity",
+        "mechanism_detail":"RNA toxicity hypothesized [doi:10.1093/brain/awz267]",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2"
+        ],
         "details":null,
-        "width":34.0,
-        "OMIM":"615127",
-        "Prevalence":null,
-        "Prevalence_details":"FAME overall is 1\/35,000 in Japan",
-        "STRipy_gene":"YEATS2",
-        "gnomAD_gene":"YEATS2",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0014055",
-        "Year":2019.0,
-        "MedGen":"767474",
-        "Orphanet":"86814",
-        "GARD":"16758",
-        "WebSTR_hg38":"5034940; 769177",
-        "WebSTR_hg19":"STR_1006941"
+        "omim":[
+            "615127"
+        ],
+        "prevalence":null,
+        "prevalence_details":"FAME overall is 1/35,000 in Japan. This repeat expansion is typically found in individuals of East Asian ancestry (PMID: 38876750)",
+        "stripy":[
+            "YEATS2"
+        ],
+        "gnomad":[
+            "YEATS2"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0014055"
+        ],
+        "year":2019.0,
+        "medgen":[
+            "767474"
+        ],
+        "orphanet":[
+            "86814"
+        ],
+        "gard":[
+            "16758"
+        ],
+        "malacard":[
+            "EPL107"
+        ],
+        "webstr_hg38":[
+            "5034940",
+            "769177"
+        ],
+        "webstr_hg19":[
+            "STR_1006941"
+        ],
+        "tr_gnomad":[
+            "TR38932"
+        ],
+        "disease_description":"Cortical tremor, seizures with generalised motor (tonic-clonic) onset (PMID: 38876750)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr16",
@@ -4103,61 +6547,89 @@
         "stop_hg19":72821657,
         "start_t2t":78605503,
         "stop_t2t":78605569,
-        "notes_t2t":"(GCC)22.3",
         "id":"SCA4_ZFHX3",
         "disease_id":"SCA4",
         "gene_strand":"-",
-        "reference_motif_reference_orientation":"GCC",
-        "pathogenic_motif_reference_orientation":"GCC",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCC"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Spinocerebellar ataxia 4",
         "gene":"ZFHX3",
         "flank_motif":null,
         "locus_structure":"(GCC)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
-        "location_in_gene":"Last Exon",
-        "normal":"16-26 (majority 21)",
-        "normal_min":16.0,
-        "normal_max":26.0,
-        "intermediate":null,
+        "location_in_gene":"Last Exon (exact exon transcript dependent)",
+        "benign_min":16.0,
+        "benign_max":26.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":"46-64",
         "pathogenic_min":46.0,
         "pathogenic_max":64.0,
         "ref_copies":21.3,
-        "repeatunitlen":3,
-        "age_onset":"Typical: 37- 56; Range: 15 - 60 (PMID: 38035881 - https:\/\/doi.org\/10.1101\/2023.10.03.23296230) ",
+        "motif_len":3,
+        "age_onset":"Typical: 37- 56; Range: 15 - 60 (PMID: 38035881 - https://doi.org/10.1101/2023.10.03.23296230) ",
         "age_onset_min":15,
         "age_onset_max":60,
         "typ_age_onset_min":37.0,
         "typ_age_onset_max":56.0,
         "novel":"ref",
-        "Mechanism":null,
-        "Mechanism_detail":null,
-        "Mechanism_source":null,
-        "source":"https:\/\/doi.org\/10.1101\/2023.10.03.23296230",
-        "notes":null,
-        "details":"Expansion found in affected individuals from 3 families and not in any of the 1001 controls. Possible anticipation (PMID: 38197134, PMID: 38035881)",
-        "width":null,
-        "OMIM":"600223",
-        "Prevalence":null,
-        "Prevalence_details":"Unknown",
-        "STRipy_gene":null,
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":"0010847",
-        "Year":2023.0,
-        "MedGen":"199815",
-        "Orphanet":"98765",
-        "GARD":"9970",
-        "WebSTR_hg38":"5977326",
-        "WebSTR_hg19":"STR_545217"
+        "mechanism":null,
+        "mechanism_detail":null,
+        "source":[
+            "https://doi.org/10.1101/2023.10.03.23296230"
+        ],
+        "details":"Expansion found in affected individuals from 3 families and not in any of the 1001 controls. Possible anticipation (PMID: 38197134, PMID: 38035881). Most unaffected individuals had 21 motifs.",
+        "omim":[
+            "600223"
+        ],
+        "prevalence":null,
+        "prevalence_details":"Observed in Swedish individuals (OMIM: 600223)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[
+            "0010847"
+        ],
+        "year":2023.0,
+        "medgen":[
+            "199815"
+        ],
+        "orphanet":[
+            "98765"
+        ],
+        "gard":[
+            "9970"
+        ],
+        "malacard":[
+            "SPN105"
+        ],
+        "webstr_hg38":[
+            "5977326"
+        ],
+        "webstr_hg19":[
+            "STR_545217"
+        ],
+        "tr_gnomad":[
+            "TR142346"
+        ],
+        "disease_description":"Spinocerebellar ataxia type 4 (SCA4) is a very rare progressive subtype of type I autosomal dominant cerebellar ataxia (ADCA type I) characterized by ataxia with sensory neuropathy. (adapted from Mondo)",
+        "locus_tags":[],
+        "disease_tags":[
+            "ataxia"
+        ]
     },
     {
         "chrom":"chr13",
@@ -4167,61 +6639,94 @@
         "stop_hg19":100637747,
         "start_t2t":99196359,
         "stop_t2t":99196404,
-        "notes_t2t":"(GCG)15.3",
         "id":"HPE5_ZIC2",
         "disease_id":"HPE5",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Holoprosencephaly-5",
         "gene":"ZIC2",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Coding",
         "location_in_gene":"Exon 3",
-        "normal":"< 15",
-        "normal_min":15.0,
-        "normal_max":15.0,
-        "intermediate":null,
+        "benign_min":15.0,
+        "benign_max":15.0,
         "intermediate_min":null,
         "intermediate_max":null,
-        "pathogenic":">25",
         "pathogenic_min":25.0,
         "pathogenic_max":25.0,
         "ref_copies":15.3,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":0.0,
         "typ_age_onset_max":0.0,
         "novel":"ref",
-        "Mechanism":"Polyalanine ",
-        "Mechanism_detail":"Polyalanine ",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977) (doi.org\/10.1007\/s11604-022-01343-5)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine ",
+        "mechanism_detail":"Polyalanine [doi:doi.org/10.1038/nature05977, doi:doi.org/10.1007/s11604-022-01343-5]",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
         "details":null,
-        "width":45.0,
-        "OMIM":"609637",
-        "Prevalence":"1.4\/1000000",
-        "Prevalence_details":"0.05-0.23\/100,000; math done by 40% of pathogenic variants in ZIC2 are expansion (GeneReview); 5% of non-syndromic HPE are ZIC2 gene (NBK1530), and nonsyndromic HPE is [25]-50% of HPE, which affects 1\/10,000 newborns (Medline non-syndromic HPE) - ZIC2 is 9.2% of HPE cases, whicho ccur in 1\/16,000 live births (PMID: 17274816)",
-        "STRipy_gene":"ZIC2",
-        "gnomAD_gene":"ZIC2",
-        "GeneReviews":"NBK1530",
-        "Mondo":"0012322",
-        "Year":2001.0,
-        "MedGen":"355304",
-        "Orphanet":"2162",
-        "GARD":"6665",
-        "WebSTR_hg38":"5374719",
-        "WebSTR_hg19":"STR_395661"
+        "omim":[
+            "609637"
+        ],
+        "prevalence":"1.4/1000000",
+        "prevalence_details":"0.05-0.23/100,000; math done by 40% of pathogenic variants in ZIC2 are expansion (GeneReview); 5% of non-syndromic HPE are ZIC2 gene (NBK1530), and nonsyndromic HPE is [25]-50% of HPE, which affects 1/10,000 newborns (Medline non-syndromic HPE) - ZIC2 is 9.2% of HPE cases, whicho ccur in 1/16,000 live births (PMID: 17274816). Holoprosencephaly has worldwide distribution (Orphanet: 2162), but STR-specific distribution is unknown",
+        "stripy":[
+            "ZIC2"
+        ],
+        "gnomad":[
+            "ZIC2"
+        ],
+        "genereviews":[
+            "NBK1530"
+        ],
+        "mondo":[
+            "0012322"
+        ],
+        "year":2001.0,
+        "medgen":[
+            "355304"
+        ],
+        "orphanet":[
+            "2162"
+        ],
+        "gard":[
+            "6665"
+        ],
+        "malacard":[
+            "HLP028"
+        ],
+        "webstr_hg38":[
+            "5374719"
+        ],
+        "webstr_hg19":[
+            "STR_395661"
+        ],
+        "tr_gnomad":[
+            "TR127312"
+        ],
+        "disease_description":"Holoprosencephaly associated with mutations in the ZIC2 gene. (Mondo)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chrX",
@@ -4231,61 +6736,92 @@
         "stop_hg19":136649015,
         "start_t2t":135876774,
         "stop_t2t":135876800,
-        "notes_t2t":"(CGC)9.0",
         "id":"VACTERLX_ZIC3",
         "disease_id":"VACTERLX",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCN",
-        "pathogenic_motif_reference_orientation":"GCN",
-        "pathogenic_motif_gene_orientation":"CNG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCN"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CNG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"X-linked VACTERL syndrome",
         "gene":"ZIC3",
         "flank_motif":null,
         "locus_structure":"(GCN)*",
-        "Inheritance":"XR",
+        "inheritance":[
+            "XR"
+        ],
         "type":"Coding",
-        "location_in_gene":null,
-        "normal":"<10",
-        "normal_min":9.0,
-        "normal_max":10.0,
-        "intermediate":"11",
+        "location_in_gene":"Exon 1",
+        "benign_min":9.0,
+        "benign_max":10.0,
         "intermediate_min":11.0,
         "intermediate_max":11.0,
-        "pathogenic":">12",
         "pathogenic_min":12.0,
         "pathogenic_max":12.0,
         "ref_copies":9.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"0",
         "age_onset_min":0,
         "age_onset_max":0,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Polyalanine",
-        "Mechanism_detail":"Polyalanine",
-        "Mechanism_source":"(doi.org\/10.1038\/nature05977)",
-        "source":"Pathogenic Short Tandem Repeats Gnomad v3.1.2, NBK535148",
-        "notes":null,
+        "mechanism":"Polyalanine",
+        "mechanism_detail":"Polyalanine [doi:doi.org/10.1038/nature05977]",
+        "source":[
+            "Pathogenic Short Tandem Repeats Gnomad v3.1.2",
+            "NBK535148"
+        ],
         "details":null,
-        "width":30.0,
-        "OMIM":"314390",
-        "Prevalence":null,
-        "Prevalence_details":"1 patient with VACTERL died at birth. 8 patients with X-linked OAVS at 11 motifs; 1 individual in OAVS cohort with 12 repeats. ",
-        "STRipy_gene":"ZIC3",
-        "gnomAD_gene":"ZIC3",
-        "GeneReviews":"NBK535148",
-        "Mondo":"0010752",
-        "Year":null,
-        "MedGen":"419019",
-        "Orphanet":null,
-        "GARD":"15309",
-        "WebSTR_hg38":"883856",
-        "WebSTR_hg19":"STR_1596381"
+        "omim":[
+            "314390"
+        ],
+        "prevalence":null,
+        "prevalence_details":"1 patient with VACTERL died at birth. 8 patients with X-linked OAVS at 11 motifs; 1 individual in OAVS cohort with 12 repeats. Found in one patient (NBK535148) with European ancestry (PMID: 20452998)",
+        "stripy":[
+            "ZIC3"
+        ],
+        "gnomad":[
+            "ZIC3"
+        ],
+        "genereviews":[
+            "NBK535148"
+        ],
+        "mondo":[
+            "0010752"
+        ],
+        "year":null,
+        "medgen":[
+            "419019"
+        ],
+        "orphanet":[],
+        "gard":[
+            "15309"
+        ],
+        "malacard":[
+            "VCT005"
+        ],
+        "webstr_hg38":[
+            "883856"
+        ],
+        "webstr_hg19":[
+            "STR_1596381"
+        ],
+        "tr_gnomad":[
+            "TR173313"
+        ],
+        "disease_description":"VACTERL is an acronym for vertebral anomalies (similar to those of spondylocostal dysplasia), anal atresia, cardiac malformations, tracheoesophageal fistula, renal anomalies (urethral atresia with hydronephrosis), and limb anomalies (OMIM: 314390)",
+        "locus_tags":[],
+        "disease_tags":[]
     },
     {
         "chrom":"chr7",
@@ -4295,60 +6831,80 @@
         "stop_hg19":55955332,
         "start_t2t":56047901,
         "stop_t2t":56047939,
-        "notes_t2t":"(GCG)15.0",
         "id":"FRA7A_ZNF713",
         "disease_id":"FRA7A",
         "gene_strand":"+",
-        "reference_motif_reference_orientation":"GCG",
-        "pathogenic_motif_reference_orientation":"GCG",
-        "pathogenic_motif_gene_orientation":"CGG",
-        "benign_motif_reference_orientation":null,
-        "benign_motif_gene_orientation":"",
-        "unknown_motif_reference_orientation":null,
-        "unknown_motif_gene_orientation":"",
+        "reference_motif_reference_orientation":[
+            "GCG"
+        ],
+        "pathogenic_motif_reference_orientation":[
+            "GCG"
+        ],
+        "pathogenic_motif_gene_orientation":[
+            "CGG"
+        ],
+        "benign_motif_reference_orientation":[],
+        "benign_motif_gene_orientation":[],
+        "unknown_motif_reference_orientation":[],
+        "unknown_motif_gene_orientation":[],
         "disease":"Autism spectrum disorder associated with fragile site FRA7A",
         "gene":"ZNF713",
         "flank_motif":null,
         "locus_structure":"(GCG)*",
-        "Inheritance":"AD",
+        "inheritance":[
+            "AD"
+        ],
         "type":"Intronic",
-        "location_in_gene":null,
-        "normal":"5-22",
-        "normal_min":5.0,
-        "normal_max":22.0,
-        "intermediate":"85",
+        "location_in_gene":"Intron 1",
+        "benign_min":5.0,
+        "benign_max":22.0,
         "intermediate_min":85.0,
         "intermediate_max":85.0,
-        "pathogenic":"450",
         "pathogenic_min":450.0,
         "pathogenic_max":450.0,
         "ref_copies":13.0,
-        "repeatunitlen":3,
+        "motif_len":3,
         "age_onset":"2-3 (four individuals; PMID: 25196122)",
         "age_onset_min":2,
         "age_onset_max":3,
         "typ_age_onset_min":null,
         "typ_age_onset_max":null,
         "novel":"ref",
-        "Mechanism":"Methylation",
-        "Mechanism_detail":"Methylation",
-        "Mechanism_source":"(OMIM)",
-        "source":"OMIM, https:\/\/pubmed.ncbi.nlm.nih.gov\/25196122\/",
-        "notes":null,
+        "mechanism":"Methylation",
+        "mechanism_detail":"Methylation (OMIM)",
+        "source":[
+            "OMIM",
+            "https://pubmed.ncbi.nlm.nih.gov/25196122/"
+        ],
         "details":null,
-        "width":38.0,
-        "OMIM":"616181",
-        "Prevalence":null,
-        "Prevalence_details":"4 individuals",
-        "STRipy_gene":null,
-        "gnomAD_gene":null,
-        "GeneReviews":null,
-        "Mondo":null,
-        "Year":null,
-        "MedGen":null,
-        "Orphanet":null,
-        "GARD":null,
-        "WebSTR_hg38":"1380240; 5696269",
-        "WebSTR_hg19":"STR_1325788"
+        "omim":[
+            "616181"
+        ],
+        "prevalence":null,
+        "prevalence_details":"4 individuals reported. Found in 2 families without discussion of ancestry/ethnicity (PMID: 25196122)",
+        "stripy":[],
+        "gnomad":[],
+        "genereviews":[],
+        "mondo":[],
+        "year":null,
+        "medgen":[],
+        "orphanet":[],
+        "gard":[],
+        "malacard":[
+            "ATS007"
+        ],
+        "webstr_hg38":[
+            "1380240",
+            "5696269"
+        ],
+        "webstr_hg19":[
+            "STR_1325788"
+        ],
+        "tr_gnomad":[
+            "TR300995"
+        ],
+        "disease_description":"A spectrum of developmental disorders that includes autism, and Asperger syndrome. Signs and symptoms include poor communication skills, defective social interactions, and repetitive behaviors (MONDO:0005258).",
+        "locus_tags":[],
+        "disease_tags":[]
     }
 ]


### PR DESCRIPTION
delete width, normal, pathogenic and intermediate fields. Any extra allele size info moved to details
delete notes_t2t field
convert field names to lowercase
rename fields: normal_min -> benign_min, normal_max -> benign_max, repeatunitlen -> motif_len removed notes field and moved content to details or another field as appropriate delete Mechanism_source and move content into mechanism_detail add locus and disease tag fields. Most are empty lists for now. convert many fields to lists

See #44 
Replaces #57 

Note: will provide a detail spec/schema in a separate PR.