### PR TITLE
add short CI workflow (requires python only, no R)

### DIFF
--- a/.github/workflows/update-loci.yaml
+++ b/.github/workflows/update-loci.yaml
@@ -1,0 +1,55 @@
+name: Update data
+
+on:
+  pull_request:
+    branches: main
+    paths:
+      - "data/**"
+      - "scripts/**"
+      - "workflow/**"
+      - ".github/workflows/**"
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Debug dump
+        uses: crazy-max/ghaction-dump-context@v2
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Miniconda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          auto-update-conda: true
+          activate-environment: strchive
+          environment-file: scripts/environment.yml
+          python-version: 3.12
+          auto-activate-base: false
+      - run: |
+          conda info
+
+      - name: Check loci and update bed files (short)
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'}}
+        run: snakemake --config stages="skip-refs"
+
+      - name: Open pull request with updated files
+        if: ${{ !(github.event_name == 'pull_request') }}
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: update-data
+          title: Update data
+
+      - name: Commit updated files to current pull request
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Update data

--- a/scripts/setup-miniconda-patched-environment.yml
+++ b/scripts/setup-miniconda-patched-environment.yml
@@ -1,0 +1,23 @@
+name: strchive
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - pandas
+  - numpy
+  - biopython
+  - defopt
+  - snakemake
+  - jsbeautifier
+  - r-base
+  - r-essentials
+  - r-jsonlite
+  - r-dplyr
+  - r-rentrez
+  - r-easypubmed
+  - r-stringr
+  - r-purrr
+  - pip
+  - pip:
+      - manubot
+  - python=3.12


### PR DESCRIPTION
I'm still working on getting the R parts of the CI working, but in the meantime, here's a python-only version.

Partially addresses #59