### PR TITLE
revert gnomad plots

### DIFF
--- a/data/plots/gnomad.json
+++ b/data/plots/gnomad.json
@@ -1,762 +1,2211 @@
 {
-  "FRAXE_AFF2":
-  {
-    "XX":
-    {
-      "id": "FRAXE_AFF2",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
+  "DRPLA_ATN1": {
+    "both": {
+      "id": "DRPLA_ATN1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6906, 2104, 117, 662, 693, 104],
       "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "AFF2_XX"
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05832761092976721, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
     },
-    "XY":
-    {
-      "id": "FRAXE_AFF2",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "counts": [301, 3916, 19, 320, 4072, 994, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.260540817122589, 0.10146949994510686, 17.55508258978055, 1.186478195250102, 0.09802081224594295, 0.3904449257972054, 6.220036485072243, 0.9288681332954924, 0.9960138516718677, 5.894387055227531],
-      "title": "AFF2_XY"
-    },
-    "id": "FRAXE_AFF2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6857, 51, 359, 6878, 2096, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05866807856354365, 6.896233766261892, 1.0589994035923531, 0.058521569913399095, 0.1916060069514427, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "AFF2"
+    "reliable": true
   },
-  "SBMA_AR":
-  {
-    "XX":
-    {
-      "id": "SBMA_AR",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "AR_XX"
+  "SCA1_ATXN1": {
+    "both": {
+      "id": "SCA1_ATXN1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.16339869281045752, 0.07250580046403712, 0, 0, 0.07237984944991314, 0,
+        0, 0.3021148036253776, 0.1443001443001443, 0
+      ],
+      "confidence_lower_bounds": [
+        0.008380906035285832, 0.028573660252211187, 0, 0, 0.028524017183089882,
+        0, 0, 0.05370615099493774, 0.007401355867869128, 0
+      ],
+      "confidence_upper_bounds": [
+        0.9515574518929341, 0.1762778306118572, 6.457909234512961,
+        1.056093661065321, 0.17599150722239262, 0.1909239663624504,
+        3.210774116809066, 1.112868766297502, 0.8418017383974706,
+        3.6112958977795095
+      ]
     },
-    "XY":
-    {
-      "id": "SBMA_AR",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0.33333333333333337, 0.051546391752577324, 0, 0, 0, 0.10090817356205853, 0, 0, 0, 0],
-      "counts": [300, 3880, 20, 321, 4077, 991, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.017096303211288414, 0.00915956266969977, 0.0, 0.0, 0.0, 0.0051757787045631646, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.7833730490226172, 0.18800013701347285, 16.682097458002666, 1.1828228501457176, 0.09791464202506578, 0.5923991640849927, 6.220036485072243, 0.9288681332954924, 0.9960138516718677, 5.894387055227531],
-      "title": "AR_XY"
-    },
-    "id": "SBMA_AR",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.16366612111292964, 0.029321213898255385, 0, 0, 0, 0.047778308647873864, 0, 0, 0, 0],
-    "counts": [611, 6821, 52, 360, 6883, 2093, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.008394622163359079, 0.005210061581770933, 0.0, 0.0, 0.0, 0.002450676821231237, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.953094241054738, 0.10694389023865095, 6.457909234512961, 1.056093661065321, 0.058486818612504515, 0.28695460865090566, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "AR"
+    "reliable": true
   },
-  "EIEE1_ARX":
-  {
-    "XX":
-    {
+  "SCA10_ATXN10": {
+    "both": {
+      "id": "SCA10_ATXN10",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA2_ATXN2": {
+    "both": {
+      "id": "SCA2_ATXN2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0, 0.0290065264684554, 0, 0, 0.014475969889982628, 0, 0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0.005154142428145123, 0, 0, 0.0007425174284353486, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.1057961729108189, 6.457909234512961,
+        1.056093661065321, 0.08533492916521204, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA3_ATXN3": {
+    "both": {
+      "id": "SCA3_ATXN3",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA7_ATXN7": {
+    "both": {
+      "id": "SCA7_ATXN7",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0, 0.014501160092807424, 0, 0, 0, 0.04752851711026616, 0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0.0007438095073221889, 0, 0, 0, 0.002437864503532627, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.08546483245872945, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.2855183626469341,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA8_ATXN8OS": {
+    "both": {
+      "id": "SCA8_ATXN8OS",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6907, 2104, 117, 662, 693, 104],
+      "values": [
+        0.32679738562091504, 0.23201856148491878, 0, 0, 0.6804690893296655,
+        0.8079847908745247, 0.8547008547008548, 0.3021148036253776,
+        0.7215007215007215, 0
+      ],
+      "confidence_lower_bounds": [
+        0.058096223043940104, 0.1393095793727247, 0, 0, 0.5049423635361422,
+        0.4898176169419368, 0.04383081404426025, 0.05370615099493774,
+        0.2847104338405359, 0
+      ],
+      "confidence_upper_bounds": [
+        1.2027511494086687, 0.37486639170304575, 6.457909234512961,
+        1.056093661065321, 0.9027563045945659, 1.3101072149485005,
+        4.565269826796625, 1.112868766297502, 1.7130760879368225,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA31_BEAN1": {
+    "both": {
+      "id": "SCA31_BEAN1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6902, 2069, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05835522303581345, 0.193946828245938,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "FTDALS1_C9orf72": {
+    "both": {
+      "id": "FTDALS1_C9orf72",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA6_CACNA1A": {
+    "both": {
+      "id": "SCA6_CACNA1A",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6894, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05841054326672513, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "DM2_CNBP": {
+    "both": {
+      "id": "DM2_CNBP",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0.5555555555555556, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [
+        0, 0, 0, 0.09880008669144427, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        2.0247977588441857, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "EDM1-PSACH_COMP": {
+    "both": {
+      "id": "EDM1-PSACH_COMP",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "EPM1_CSTB": {
+    "both": {
+      "id": "EPM1_CSTB",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA37_DAB1": {
+    "both": {
+      "id": "SCA37_DAB1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2102, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05840362120081246, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.19109398987343162,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "FRA12A_DIP2B": {
+    "both": {
+      "id": "FRA12A_DIP2B",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "DM1_DMPK": {
+    "both": {
+      "id": "DM1_DMPK",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.32679738562091504, 0, 0, 0, 0.04342790966994789, 0, 0, 0,
+        0.1443001443001443, 0
+      ],
+      "confidence_lower_bounds": [
+        0.058096223043940104, 0, 0, 0, 0.011837889802296749, 0, 0, 0,
+        0.007401355867869128, 0
+      ],
+      "confidence_upper_bounds": [
+        1.2027511494086687, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.12749429404297122, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.8418017383974706,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "RCPS_EIF4A3": {
+    "both": {
+      "id": "RCPS_EIF4A3",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "BPES_FOXL2": {
+    "both": {
+      "id": "BPES_FOXL2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6893, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.8169934640522877, 0.11605977078195272, 0, 0, 0.5790387955993052,
+        0.2376425855513308, 0, 0, 0, 0.9615384615384616
+      ],
+      "confidence_lower_bounds": [
+        0.3224554840124706, 0.05460911648511263, 0, 0, 0.420639557960387,
+        0.09368349968595592, 0, 0, 0, 0.049308314825326986
+      ],
+      "confidence_upper_bounds": [
+        1.9380906001563798, 0.22949369011881948, 6.457909234512961,
+        1.056093661065321, 0.7867839184398958, 0.5725802360520895,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        5.134335183190326
+      ]
+    },
+    "reliable": false
+  },
+  "FRDA_FXN": {
+    "both": {
+      "id": "FRDA_FXN",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "OPDM2_GIPC1": {
+    "both": {
+      "id": "OPDM2_GIPC1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0.058004640371229696, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [
+        0, 0.01981554913200106, 0, 0, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.14946046613371428, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "GDPAG_GLS": {
+    "both": {
+      "id": "GDPAG_GLS",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "HFG_HOXA13-I": {
+    "both": {
+      "id": "HFG_HOXA13-I",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        9.640522875816995, 9.005220417633412, 0, 8.055555555555555,
+        17.02374059061957, 7.41444866920152, 10.256410256410255,
+        9.667673716012084, 12.265512265512266, 17.307692307692307
+      ],
+      "confidence_lower_bounds": [
+        7.4933807946890525, 8.343632459347536, 0, 5.588344754858964,
+        16.153797883986716, 6.36285101302113, 5.867521815697999,
+        7.608698822768847, 10.01248342740983, 10.905717673442343
+      ],
+      "confidence_upper_bounds": [
+        12.236429395054959, 9.71164906433963, 6.457909234512961,
+        11.35378583344762, 17.927183621266046, 8.630485288239488,
+        17.01133138090239, 12.143780114503508, 14.920011143217343,
+        25.87958585549513
+      ]
+    },
+    "reliable": false
+  },
+  "HFG_HOXA13-II": {
+    "both": {
+      "id": "HFG_HOXA13-II",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        12.418300653594772, 11.600928074245939, 1.9230769230769231,
+        13.88888888888889, 23.34973943254198, 12.11977186311787,
+        22.22222222222222, 14.954682779456194, 19.913419913419915, 25
+      ],
+      "confidence_lower_bounds": [
+        9.970196346495037, 10.859672510256027, 0.0985923165515654,
+        10.663021188137698, 22.36423301763791, 10.783541659196343,
+        15.261305028607545, 12.36716138189876, 17.0857275459674,
+        17.22925453204114
+      ],
+      "confidence_upper_bounds": [
+        15.261296723039813, 12.386202671349302, 10.244332921927223,
+        17.88757844299875, 24.36200659299934, 13.588017964309044,
+        30.71355680168647, 17.88555598372796, 23.075919996175763,
+        34.091001320212186
+      ]
+    },
+    "reliable": false
+  },
+  "HFG_HOXA13-III": {
+    "both": {
+      "id": "HFG_HOXA13-III",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        12.254901960784313, 3.7412993039443156, 1.9230769230769231,
+        1.3888888888888888, 7.614360162130862, 10.884030418250951,
+        5.982905982905983, 17.220543806646525, 13.131313131313133,
+        7.6923076923076925
+      ],
+      "confidence_lower_bounds": [
+        9.86665962074906, 3.311385865306486, 0.0985923165515654,
+        0.5488152883677645, 7.004458758253443, 9.61525272635543,
+        2.8413345567850508, 14.484461805078741, 10.790076944272993,
+        3.6112957920560267
+      ],
+      "confidence_upper_bounds": [
+        15.097160361159553, 4.221485963175353, 10.244332921927223,
+        3.2750340471149735, 8.264032286314427, 12.304121229184076,
+        11.854161595304971, 20.30340907070035, 15.858148038633264,
+        14.754539629054552
+      ]
+    },
+    "reliable": false
+  },
+  "SD5_HOXD13": {
+    "both": {
+      "id": "SD5_HOXD13",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0.028951939779965255, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [
+        0, 0, 0, 0, 0.005144442518598504, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.10559708612589468, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "HD_HTT": {
+    "both": {
+      "id": "HD_HTT",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.16339869281045752, 0.0145032632342277, 0, 0, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.008380906035285832, 0.0007439173835717394, 0, 0, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.9515574518929341, 0.08547567815258797, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "HDL2_JPH3": {
+    "both": {
+      "id": "HDL2_JPH3",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0.014501160092807424, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [
+        0, 0.0007438095073221889, 0, 0, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.08546483245872945, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "OPDM1_LRP12": {
+    "both": {
+      "id": "OPDM1_LRP12",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "FAME3_MARCHF6": {
+    "both": {
+      "id": "FAME3_MARCHF6",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6907, 2102, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05832071289141027, 0.19109398987343162,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "ALS1_NIPA1": {
+    "both": {
+      "id": "ALS1_NIPA1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2103, 117, 662, 693, 104],
+      "values": [
+        0, 0.10152284263959391, 0, 0, 0.21713954834973945, 0.14265335235378032,
+        0, 0.1510574018126888, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0.04765718183814036, 0, 0, 0.1274942918401005, 0.038893077631218555,
+        0, 0.0077479316128444406, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.20796972918207232, 6.457909234512961,
+        1.056093661065321, 0.36174810565816634, 0.418755132767338,
+        3.210774116809066, 0.8806355413232516, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "SCA36_NOP56": {
+    "both": {
+      "id": "SCA36_NOP56",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "NIID_NOTCH2NLC": {
+    "both": {
+      "id": "NIID_NOTCH2NLC",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6902, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05840362120081246, 6.457909234512961,
+        1.056093661065321, 0.05835522303581345, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "OPML1_NUTM2B-AS1": {
+    "both": {
+      "id": "OPML1_NUTM2B-AS1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [611, 6891, 52, 358, 6902, 2102, 117, 661, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6274402119292116, 0.058431321561937796, 6.457909234512961,
+        1.0619213684396163, 0.05835522303581345, 0.19109398987343162,
+        3.210774116809066, 0.5809201676011098, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "OPMD_PABPN1": {
+    "both": {
+      "id": "OPMD_PABPN1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0, 0, 0, 0, 0.11580775911986102, 0, 0, 0.1510574018126888, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0, 0, 0, 0.05449054293930325, 0, 0, 0.0077479316128444406, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.22899539136692798, 0.1909239663624504,
+        3.210774116809066, 0.8806355413232516, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "CCHS_PHOX2B": {
+    "both": {
+      "id": "CCHS_PHOX2B",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        1.6339869281045754, 0.37703016241299303, 1.9230769230769231, 0,
+        1.2159814707585408, 2.6615969581749046, 0, 0.6042296072507553,
+        0.5772005772005772, 2.8846153846153846
+      ],
+      "confidence_lower_bounds": [
+        0.8731963836696964, 0.25082777565497477, 0.0985923165515654, 0,
+        0.9776967877839632, 2.0358275484750625, 0, 0.20664779202041794,
+        0.19739287160382854, 0.7907621311254991
+      ],
+      "confidence_upper_bounds": [
+        3.005621584225851, 0.5556278584641053, 10.244332921927223,
+        1.056093661065321, 1.5033595888034053, 3.43916122978479,
+        3.210774116809066, 1.5674930745677127, 1.4979490959489725,
+        8.042538478931494
+      ]
+    },
+    "reliable": false
+  },
+  "SCA12_PPP2R2B": {
+    "both": {
+      "id": "SCA12_PPP2R2B",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "HSAN-VIII_PRDM12": {
+    "both": {
+      "id": "HSAN-VIII_PRDM12",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "CJD_PRNP": {
+    "both": {
+      "id": "CJD_PRNP",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0, 0, 0, 0, 0.07237984944991314, 0.04752851711026616, 0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0, 0, 0, 0.028524017183089882, 0.002437864503532627, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.17599150722239262, 0.2855183626469341,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "FAME7_RAPGEF2": {
+    "both": {
+      "id": "FAME7_RAPGEF2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2096, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1916060069514427,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "CANVAS_RFC1": {
+    "both": {
+      "id": "CANVAS_RFC1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [611, 6896, 52, 360, 6907, 2102, 117, 662, 691, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6274402119292116, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05832071289141027, 0.19109398987343162,
+        3.210774116809066, 0.580061416818756, 0.5562384558357876,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "OPDM4_RILPL1": {
+    "both": {
+      "id": "OPDM4_RILPL1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05840362120081246, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "CCD_RUNX2": {
+    "both": {
+      "id": "CCD_RUNX2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6893, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.9803921568627451, 0.8994632235601334, 0, 0.5555555555555556,
+        1.5344528083381586, 0.5703422053231939, 0.8547008547008548,
+        1.6616314199395772, 1.443001443001443, 2.8846153846153846
+      ],
+      "confidence_lower_bounds": [
+        0.4277991108156977, 0.6966894787431169, 0, 0.09880008669144427,
+        1.2643556532411697, 0.3183072385145839, 0.04383081404426025,
+        0.8691481912250453, 0.7707859658672868, 0.7907621311254991
+      ],
+      "confidence_upper_bounds": [
+        2.0999217430370702, 1.1511932582908002, 6.457909234512961,
+        2.0247977588441857, 1.8509255215339842, 0.9907342795816313,
+        4.565269826796625, 3.0023893481734087, 2.645036295165834,
+        8.042538478931494
+      ]
+    },
+    "reliable": false
+  },
+  "FAME1_SAMD12": {
+    "both": {
+      "id": "FAME1_SAMD12",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6890, 52, 360, 6906, 2093, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05843825165560828, 6.457909234512961,
+        1.056093661065321, 0.05832761092976721, 0.19186311615217477,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "FAME2_STARD7": {
+    "both": {
+      "id": "FAME2_STARD7",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2101, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.19117912299776846,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "SCA17_TBP": {
+    "both": {
+      "id": "SCA17_TBP",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "TOF_TBX1": {
+    "both": {
+      "id": "TOF_TBX1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.32679738562091504, 0.10152284263959391, 0, 0, 0.5500868558193398,
+        0.19011406844106463, 0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.058096223043940104, 0.04765718183814036, 0, 0, 0.3955239573056369,
+        0.06496431764312231, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        1.2027511494086687, 0.20796972918207232, 6.457909234512961,
+        1.056093661065321, 0.76255496838888, 0.5017087701974934,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "FECD3_TCF4": {
+    "both": {
+      "id": "FECD3_TCF4",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        3.9215686274509802, 2.2041763341067284, 1.9230769230769231,
+        3.3333333333333335, 6.572090330052113, 4.0399239543726235,
+        0.8547008547008548, 3.474320241691843, 3.0303030303030303,
+        5.769230769230769
+      ],
+      "confidence_lower_bounds": [
+        2.58364862302214, 1.8755908457496453, 0.0985923165515654,
+        1.8754706187118924, 6.005614010392344, 3.2731824680839448,
+        0.04383081404426025, 2.290798574298985, 1.916446947929408,
+        2.5420315689954966
+      ],
+      "confidence_upper_bounds": [
+        5.777018116589709, 2.5791344578394075, 10.244332921927223,
+        5.786269430053519, 7.185415602388441, 4.994017066303614,
+        4.565269826796625, 5.187220820937397, 4.595857734524972,
+        11.910724072167252
+      ]
+    },
+    "reliable": true
+  },
+  "FAME6_TNRC6A": {
+    "both": {
+      "id": "FAME6_TNRC6A",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6895, 52, 360, 6908, 2097, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05840362120081246, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.19152046726522548,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "HMNR7_VWA1": {
+    "both": {
+      "id": "HMNR7_VWA1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        2.6143790849673203, 0.3190255220417633, 0, 0, 0.390851187029531,
+        4.134980988593155, 0, 0, 0, 1.9230769230769231
+      ],
+      "confidence_lower_bounds": [
+        1.5832362795041677, 0.20793956981203995, 0, 0, 0.26545588639162876,
+        3.3432879550605143, 0, 0, 0, 0.3427601671968367
+      ],
+      "confidence_upper_bounds": [
+        4.2219654634676305, 0.4833890355717739, 6.457909234512961,
+        1.056093661065321, 0.5693947152666117, 5.0895895820233905,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        6.598830830498273
+      ]
+    },
+    "reliable": true
+  },
+  "DBQD2_XYLT1": {
+    "both": {
+      "id": "DBQD2_XYLT1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05839670121277325, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.1909239663624504,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "FAME4_YEATS2": {
+    "both": {
+      "id": "FAME4_YEATS2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6889, 52, 360, 6908, 2102, 117, 662, 692, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05844518368582516, 6.457909234512961,
+        1.056093661065321, 0.05831381689826813, 0.19109398987343162,
+        3.210774116809066, 0.580061416818756, 0.5554525747663754,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "HPE5_ZIC2": {
+    "both": {
+      "id": "HPE5_ZIC2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6896, 52, 360, 6908, 2104, 117, 662, 693, 104],
+      "values": [
+        0.49019607843137253, 0.20301624129930393, 0, 0, 0.6948465547191662,
+        0.38022813688212925, 0, 0, 0.1443001443001443, 0
+      ],
+      "confidence_lower_bounds": [
+        0.1337390196569911, 0.11757392051875191, 0, 0, 0.5186138302635641,
+        0.17889162934606184, 0, 0, 0.007401355867869128, 0
+      ],
+      "confidence_upper_bounds": [
+        1.4496873128399737, 0.33861881391668724, 6.457909234512961,
+        1.056093661065321, 0.9283262944608791, 0.7635736733534332,
+        3.210774116809066, 0.580061416818756, 0.8418017383974706,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "FRAXE_AFF2": {
+    "XX": {
+      "id": "FRAXE_AFF2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
+    },
+    "XY": {
+      "id": "FRAXE_AFF2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3916, 19, 320, 4072, 993, 54, 410, 382, 57],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.260540817122589, 0.10146949994510686, 17.55508258978055,
+        1.186478195250102, 0.09802081224594295, 0.39082573069485727,
+        6.220036485072243, 0.9288681332954924, 0.9960138516718677,
+        5.894387055227531
+      ]
+    },
+    "both": {
+      "id": "FRAXE_AFF2",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6857, 51, 359, 6878, 2095, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05866807856354365, 6.896233766261892,
+        1.0589994035923531, 0.058521569913399095, 0.19169162813185123,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
+  },
+  "SBMA_AR": {
+    "XX": {
+      "id": "SBMA_AR",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
+    },
+    "XY": {
+      "id": "SBMA_AR",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [300, 3880, 20, 321, 4077, 990, 54, 410, 382, 57],
+      "values": [
+        0.33333333333333337, 0.051546391752577324, 0, 0, 0, 0.10101010101010101,
+        0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.017096303211288414, 0.00915956266969977, 0, 0, 0,
+        0.005181006628425315, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        1.7833730490226172, 0.18800013701347285, 16.682097458002666,
+        1.1828228501457176, 0.09791464202506578, 0.5929850702829637,
+        6.220036485072243, 0.9288681332954924, 0.9960138516718677,
+        5.894387055227531
+      ]
+    },
+    "both": {
+      "id": "SBMA_AR",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [611, 6821, 52, 360, 6883, 2092, 117, 662, 693, 104],
+      "values": [
+        0.16366612111292964, 0.029321213898255385, 0, 0, 0, 0.04780114722753346,
+        0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.008394622163359079, 0.005210061581770933, 0, 0, 0,
+        0.0024518482585053993, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.953094241054738, 0.10694389023865095, 6.457909234512961,
+        1.056093661065321, 0.058486818612504515, 0.28708592522128684,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
+  },
+  "EIEE1_ARX": {
+    "XX": {
       "id": "EIEE1_ARX",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
       "values": [0, 0, 0, 0, 0.03563791874554526, 0, 0, 0, 0, 0],
-      "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0018279695500016176, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.21714797972818833, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "ARX_1_XX"
+      "confidence_lower_bounds": [
+        0, 0, 0, 0, 0.0018279695500016176, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.21714797972818833, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
     },
-    "XY":
-    {
+    "XY": {
       "id": "EIEE1_ARX",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [2.6578073089700998, 0.4334523202447731, 0, 0, 0.5401424011784924, 1.627670396744659, 0, 0, 0, 3.508771929824561],
-      "counts": [301, 3922, 19, 321, 4073, 983, 54, 410, 382, 57],
-      "confidence_lowerbounds": [1.2495540198839756, 0.2627855320210734, 0.0, 0.0, 0.35205076641625077, 0.9822829456659965, 0.0, 0.0, 0.0, 0.6270119974442079],
-      "confidence_upperbounds": [5.105699578917284, 0.6999313466472988, 17.55508258978055, 1.1828228501457176, 0.818399482789052, 2.6290230883578873, 6.220036485072243, 0.9288681332954924, 0.9960138516718677, 12.015698118917378],
-      "title": "ARX_1_XY"
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3922, 19, 321, 4073, 982, 54, 410, 382, 57],
+      "values": [
+        2.6578073089700998, 0.4334523202447731, 0, 0, 0.5401424011784924,
+        1.6293279022403258, 0, 0, 0, 3.508771929824561
+      ],
+      "confidence_lower_bounds": [
+        1.2495540198839756, 0.2627855320210734, 0, 0, 0.35205076641625077,
+        0.9832890500059388, 0, 0, 0, 0.6270119974442079
+      ],
+      "confidence_upper_bounds": [
+        5.105699578917284, 0.6999313466472988, 17.55508258978055,
+        1.1828228501457176, 0.818399482789052, 2.631699437660975,
+        6.220036485072243, 0.9288681332954924, 0.9960138516718677,
+        12.015698118917378
+      ]
     },
-    "id": "EIEE1_ARX",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [1.3071895424836601, 0.2477050852396911, 0, 0, 0.3343509230992877, 0.7673860911270983, 0, 0, 0, 1.9230769230769231],
-    "counts": [612, 6863, 51, 360, 6879, 2085, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.61482872054382, 0.15017909627479847, 0.0, 0.0, 0.21729436158970944, 0.4616709806999129, 0.0, 0.0, 0.0, 0.3427601671968367],
-    "confidence_upperbounds": [2.594449577842269, 0.3999945290449539, 6.896233766261892, 1.056093661065321, 0.49940822363698145, 1.2397041869775065, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 6.598830830498273],
-    "title": "ARX_1"
+    "both": {
+      "id": "EIEE1_ARX",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6863, 51, 360, 6879, 2084, 117, 662, 693, 104],
+      "values": [
+        1.3071895424836601, 0.2477050852396911, 0, 0, 0.3343509230992877,
+        0.7677543186180422, 0, 0, 0, 1.9230769230769231
+      ],
+      "confidence_lower_bounds": [
+        0.61482872054382, 0.15017909627479847, 0, 0, 0.21729436158970944,
+        0.4618931356536042, 0, 0, 0, 0.3427601671968367
+      ],
+      "confidence_upper_bounds": [
+        2.594449577842269, 0.3999945290449539, 6.896233766261892,
+        1.056093661065321, 0.49940822363698145, 1.2402989588570752,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        6.598830830498273
+      ]
+    },
+    "reliable": true
   },
-  "PRTS_ARX":
-  {
-    "XX":
-    {
+  "PRTS_ARX": {
+    "XX": {
       "id": "PRTS_ARX",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
       "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "ARX_2_XX"
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
     },
-    "XY":
-    {
+    "XY": {
       "id": "PRTS_ARX",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [1.6611295681063125, 0.38245792962774094, 0, 0.3115264797507788, 0.6389776357827476, 1.4213197969543148, 0, 0.7317073170731708, 0, 0],
-      "counts": [301, 3922, 19, 321, 4069, 985, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.6567565544823527, 0.2245540375203383, 0.0, 0.01597794282604984, 0.4250816577246989, 0.8266420481570071, 0.0, 0.19972532112329036, 0.0, 0.0],
-      "confidence_upperbounds": [3.7745357356394145, 0.6366290371387482, 17.55508258978055, 1.7093073880720209, 0.9436354368306625, 2.36998560989212, 6.220036485072243, 2.1574213422031203, 0.9960138516718677, 5.894387055227531],
-      "title": "ARX_2_XY"
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3922, 19, 321, 4069, 984, 54, 410, 382, 57],
+      "values": [
+        1.6611295681063125, 0.38245792962774094, 0, 0.3115264797507788,
+        0.6389776357827476, 1.4227642276422763, 0, 0.7317073170731708, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.6567565544823527, 0.2245540375203383, 0, 0.01597794282604984,
+        0.4250816577246989, 0.8274862405202787, 0, 0.19972532112329036, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        3.7745357356394145, 0.6366290371387482, 17.55508258978055,
+        1.7093073880720209, 0.9436354368306625, 2.3723933470312675,
+        6.220036485072243, 2.1574213422031203, 0.9960138516718677,
+        5.894387055227531
+      ]
     },
-    "id": "PRTS_ARX",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.8169934640522877, 0.21856331050560981, 0, 0.2777777777777778, 0.3781818181818182, 0.6708193579300431, 0, 0.4531722054380665, 0, 0],
-    "counts": [612, 6863, 51, 360, 6875, 2087, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.3224554840124706, 0.1283302217763984, 0.0, 0.01424712233094707, 0.25159390779119184, 0.3891354930063284, 0.0, 0.12362884119770147, 0.0, 0.0],
-    "confidence_upperbounds": [1.9380906001563798, 0.36404491085825486, 6.896233766261892, 1.6086695140648988, 0.5573249718012622, 1.1187579578792302, 3.210774116809066, 1.3411635875221122, 0.5546689609540219, 3.6112958977795095],
-    "title": "ARX_2"
+    "both": {
+      "id": "PRTS_ARX",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6863, 51, 360, 6875, 2086, 117, 662, 693, 104],
+      "values": [
+        0.8169934640522877, 0.21856331050560981, 0, 0.2777777777777778,
+        0.3781818181818182, 0.6711409395973155, 0, 0.4531722054380665, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.3224554840124706, 0.1283302217763984, 0, 0.01424712233094707,
+        0.25159390779119184, 0.38932247737741027, 0, 0.12362884119770147, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        1.9380906001563798, 0.36404491085825486, 6.896233766261892,
+        1.6086695140648988, 0.5573249718012622, 1.1192941883713416,
+        3.210774116809066, 1.3411635875221122, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
   },
-  "DRPLA_ATN1":
-  {
-    "id": "DRPLA_ATN1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6906, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05832761092976721, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "ATN1"
-  },
-  "SCA1_ATXN1":
-  {
-    "id": "SCA1_ATXN1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.16339869281045752, 0.07250580046403712, 0, 0, 0.07237984944991314, 0, 0, 0.3021148036253776, 0.1443001443001443, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.008380906035285832, 0.028573660252211187, 0.0, 0.0, 0.028524017183089882, 0.0, 0.0, 0.05370615099493774, 0.007401355867869128, 0.0],
-    "confidence_upperbounds": [0.9515574518929341, 0.1762778306118572, 6.457909234512961, 1.056093661065321, 0.17599150722239262, 0.19083907577318818, 3.210774116809066, 1.112868766297502, 0.8418017383974706, 3.6112958977795095],
-    "title": "ATXN1"
-  },
-  "SCA10_ATXN10":
-  {
-    "id": "SCA10_ATXN10",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "ATXN10"
-  },
-  "SCA2_ATXN2":
-  {
-    "id": "SCA2_ATXN2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0.0290065264684554, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6895, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.005154142428145123, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.1057961729108189, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "ATXN2"
-  },
-  "SCA3_ATXN3":
-  {
-    "id": "SCA3_ATXN3",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "ATXN3"
-  },
-  "SCA7_ATXN7":
-  {
-    "id": "SCA7_ATXN7",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "ATXN7"
-  },
-  "SCA8_ATXN8OS":
-  {
-    "id": "SCA8_ATXN8OS",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.32679738562091504, 0.23201856148491878, 0, 0, 0.6804690893296655, 0.8076009501187649, 0.8547008547008548, 0.3021148036253776, 0.7215007215007215, 0],
-    "counts": [612, 6896, 52, 360, 6907, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.058096223043940104, 0.1393095793727247, 0.0, 0.0, 0.5049423635361422, 0.489584957769788, 0.04383081404426025, 0.05370615099493774, 0.2847104338405359, 0.0],
-    "confidence_upperbounds": [1.2027511494086687, 0.37486639170304575, 6.457909234512961, 1.056093661065321, 0.9027563045945659, 1.3094907248356602, 4.565269826796625, 1.112868766297502, 1.7130760879368225, 3.6112958977795095],
-    "title": "ATXN8OS"
-  },
-  "SCA31_BEAN1":
-  {
-    "id": "SCA31_BEAN1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6897, 52, 360, 6903, 2070, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05838978321111312, 6.457909234512961, 1.056093661065321, 0.058348316998260666, 0.19385904242703267, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "BEAN1"
-  },
-  "FTDALS1_C9orf72":
-  {
-    "id": "FTDALS1_C9orf72",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "C9ORF72"
-  },
-  "SCA6_CACNA1A":
-  {
-    "id": "SCA6_CACNA1A",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6894, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05841054326672513, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "CACNA1A"
-  },
-  "DM2_CNBP":
-  {
-    "id": "DM2_CNBP",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0.5555555555555556, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.09880008669144427, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 2.0247977588441857, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "CNBP"
-  },
-  "EDM1-PSACH_COMP":
-  {
-    "id": "EDM1-PSACH_COMP",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "COMP"
-  },
-  "EPM1_CSTB":
-  {
-    "id": "EPM1_CSTB",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "CSTB"
-  },
-  "SCA37_DAB1":
-  {
-    "id": "SCA37_DAB1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6909, 2103, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.058306922829944305, 0.19100893769620714, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "DAB1"
-  },
-  "FRA12A_DIP2B":
-  {
-    "id": "FRA12A_DIP2B",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "DIP2B"
-  },
-  "DMD_DMD":
-  {
-    "XX":
-    {
+  "DMD_DMD": {
+    "XX": {
       "id": "DMD_DMD",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0.3215434083601286, 0.17001020061203673, 0, 0, 0, 0, 0, 0, 0, 0],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
       "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.016491660679448218, 0.06701223805810408, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.7638613418890143, 0.4131155136773779, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "DMD_XX"
+      "values": [
+        0.3215434083601286, 0.17001020061203673, 0, 0, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_lower_bounds": [
+        0.016491660679448218, 0.06701223805810408, 0, 0, 0, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        1.7638613418890143, 0.4131155136773779, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
     },
-    "XY":
-    {
+    "XY": {
       "id": "DMD_DMD",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [1.3289036544850499, 11.208677685950413, 0, 0, 0.31815956926089084, 0.1002004008016032, 5.555555555555555, 1.2195121951219512, 0.7853403141361256, 1.7543859649122806],
-      "counts": [301, 3872, 20, 321, 4086, 998, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.4551648137547567, 10.250211310271478, 0.0, 0.0, 0.17852258674430585, 0.005139476580426725, 1.531190817692249, 0.48171964072398193, 0.2143876319673316, 0.0899477584969809],
-      "confidence_upperbounds": [3.421117295976772, 12.238980268786602, 16.682097458002666, 1.1828228501457176, 0.550703454273824, 0.5883306892774908, 15.459008164408328, 2.8758876648407767, 2.303920290469936, 9.349062542783109],
-      "title": "DMD_XY"
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3872, 20, 321, 4086, 997, 54, 410, 382, 57],
+      "values": [
+        1.3289036544850499, 11.208677685950413, 0, 0, 0.31815956926089084,
+        0.10030090270812438, 5.555555555555555, 1.2195121951219512,
+        0.7853403141361256, 1.7543859649122806
+      ],
+      "confidence_lower_bounds": [
+        0.4551648137547567, 10.250211310271478, 0, 0, 0.17852258674430585,
+        0.005144631389227726, 1.531190817692249, 0.48171964072398193,
+        0.2143876319673316, 0.0899477584969809
+      ],
+      "confidence_upper_bounds": [
+        3.421117295976772, 12.238980268786602, 16.682097458002666,
+        1.1828228501457176, 0.550703454273824, 0.5889084031058962,
+        15.459008164408328, 2.8758876648407767, 2.303920290469936,
+        9.349062542783109
+      ]
     },
-    "id": "DMD_DMD",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.8169934640522877, 6.44356377513577, 0, 0, 0.1886244921648288, 0.047619047619047616, 2.564102564102564, 0.7552870090634441, 0.4329004329004329, 0.9615384615384616],
-    "counts": [612, 6813, 52, 360, 6892, 2100, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.3224554840124706, 5.87645049980117, 0.0, 0.0, 0.10584222066213314, 0.002442507998257908, 0.70244866343095, 0.2980633272180105, 0.1180938166572109, 0.049308314825326986],
-    "confidence_upperbounds": [1.9380906001563798, 7.050890754025901, 6.457909234512961, 1.056093661065321, 0.3267123437937345, 0.2860388932426237, 7.151128712024274, 1.792691030802384, 1.2817401533499848, 5.134335183190326],
-    "title": "DMD"
+    "both": {
+      "id": "DMD_DMD",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6813, 52, 360, 6892, 2099, 117, 662, 693, 104],
+      "values": [
+        0.8169934640522877, 6.44356377513577, 0, 0, 0.1886244921648288,
+        0.04764173415912339, 2.564102564102564, 0.7552870090634441,
+        0.4329004329004329, 0.9615384615384616
+      ],
+      "confidence_lower_bounds": [
+        0.3224554840124706, 5.87645049980117, 0, 0, 0.10584222066213314,
+        0.002443671637207207, 0.70244866343095, 0.2980633272180105,
+        0.1180938166572109, 0.049308314825326986
+      ],
+      "confidence_upper_bounds": [
+        1.9380906001563798, 7.050890754025901, 6.457909234512961,
+        1.056093661065321, 0.3267123437937345, 0.2861693357862237,
+        7.151128712024274, 1.792691030802384, 1.2817401533499848,
+        5.134335183190326
+      ]
+    },
+    "reliable": true
   },
-  "DM1_DMPK":
-  {
-    "id": "DM1_DMPK",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.32679738562091504, 0, 0, 0, 0.04342790966994789, 0, 0, 0, 0.1443001443001443, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.058096223043940104, 0.0, 0.0, 0.0, 0.011837889802296749, 0.0, 0.0, 0.0, 0.007401355867869128, 0.0],
-    "confidence_upperbounds": [1.2027511494086687, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.12749429404297122, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.8418017383974706, 3.6112958977795095],
-    "title": "DMPK"
-  },
-  "RCPS_EIF4A3":
-  {
-    "id": "RCPS_EIF4A3",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "EIF4A3"
-  },
-  "FXS_FMR1":
-  {
-    "XX":
-    {
+  "FXS_FMR1": {
+    "XX": {
       "id": "FXS_FMR1",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
       "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "FMR1_XX"
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
     },
-    "XY":
-    {
+    "XY": {
       "id": "FXS_FMR1",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3923, 20, 321, 4081, 995, 54, 410, 382, 57],
       "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-      "counts": [301, 3923, 20, 321, 4081, 996, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.260540817122589, 0.10130887403052495, 16.682097458002666, 1.1828228501457176, 0.09782989323892836, 0.3896856094588401, 6.220036485072243, 0.9288681332954924, 0.9960138516718677, 5.894387055227531],
-      "title": "FMR1_XY"
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.260540817122589, 0.10130887403052495, 16.682097458002666,
+        1.1828228501457176, 0.09782989323892836, 0.39006488620677876,
+        6.220036485072243, 0.9288681332954924, 0.9960138516718677,
+        5.894387055227531
+      ]
     },
-    "id": "FXS_FMR1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6864, 52, 360, 6887, 2098, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05861914271715632, 6.457909234512961, 1.056093661065321, 0.05845905397402573, 0.19143500917933343, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "FMR1"
+    "both": {
+      "id": "FXS_FMR1",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6864, 52, 360, 6887, 2097, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.05861914271715632, 6.457909234512961,
+        1.056093661065321, 0.05845905397402573, 0.19152046726522548,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
   },
-  "BPES_FOXL2":
-  {
-    "id": "BPES_FOXL2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.8169934640522877, 0.11605977078195272, 0, 0, 0.5790387955993052, 0.23752969121140144, 0, 0, 0, 0.9615384615384616],
-    "counts": [612, 6893, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.3224554840124706, 0.05460911648511263, 0.0, 0.0, 0.420639557960387, 0.09363897297168297, 0.0, 0.0, 0.0, 0.049308314825326986],
-    "confidence_upperbounds": [1.9380906001563798, 0.22949369011881948, 6.457909234512961, 1.056093661065321, 0.7867839184398958, 0.5723140623621934, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 5.134335183190326],
-    "title": "FOXL2"
-  },
-  "FRDA_FXN":
-  {
-    "id": "FRDA_FXN",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "FXN"
-  },
-  "OPDM2_GIPC1":
-  {
-    "id": "OPDM2_GIPC1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0.04350348027842227, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.011858491142777915, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.1277161421178961, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "GIPC1"
-  },
-  "GDPAG_GLS":
-  {
-    "id": "GDPAG_GLS",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "GLS"
-  },
-  "HFG_HOXA13-I":
-  {
-    "id": "HFG_HOXA13-I",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [9.640522875816995, 9.005220417633412, 0, 8.055555555555555, 17.02374059061957, 7.410926365795724, 10.256410256410255, 9.667673716012084, 12.265512265512266, 17.307692307692307],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [7.4933807946890525, 8.343632459347536, 0.0, 5.588344754858964, 16.153797883986716, 6.359828729558091, 5.867521815697999, 7.608698822768847, 10.01248342740983, 10.905717673442343],
-    "confidence_upperbounds": [12.236429395054959, 9.71164906433963, 6.457909234512961, 11.35378583344762, 17.927183621266046, 8.626391646685795, 17.01133138090239, 12.143780114503508, 14.920011143217343, 25.87958585549513],
-    "title": "HOXA13_1"
-  },
-  "HFG_HOXA13-II":
-  {
-    "id": "HFG_HOXA13-II",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [12.418300653594772, 11.600928074245939, 1.9230769230769231, 13.88888888888889, 23.34973943254198, 12.114014251781473, 22.22222222222222, 14.954682779456194, 19.913419913419915, 25.0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [9.970196346495037, 10.859672510256027, 0.0985923165515654, 10.663021188137698, 22.36423301763791, 10.778419509080011, 15.261305028607545, 12.36716138189876, 17.0857275459674, 17.22925453204114],
-    "confidence_upperbounds": [15.261296723039813, 12.386202671349302, 10.244332921927223, 17.88757844299875, 24.36200659299934, 13.581563614845612, 30.71355680168647, 17.88555598372796, 23.075919996175763, 34.091001320212186],
-    "title": "HOXA13_2"
-  },
-  "HFG_HOXA13-III":
-  {
-    "id": "HFG_HOXA13-III",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [13.071895424836603, 3.8718097447795823, 1.9230769230769231, 1.3888888888888888, 7.87492762015055, 11.401425178147269, 6.837606837606838, 18.27794561933535, 13.564213564213565, 7.6923076923076925],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [10.601969210688463, 3.4346662991298875, 0.0985923165515654, 0.5488152883677645, 7.257873207703246, 10.088932254392303, 3.2107740279904746, 15.466761687174976, 11.165247528245603, 3.6112957920560267],
-    "confidence_upperbounds": [15.99563310672954, 4.359122447755562, 10.244332921927223, 3.2750340471149735, 8.538976328519617, 12.844776198577762, 13.117575842404106, 21.436402685423456, 16.36170522426624, 14.754539629054552],
-    "title": "HOXA13_3"
-  },
-  "SD5_HOXD13":
-  {
-    "id": "SD5_HOXD13",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0.028951939779965255, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.005144442518598504, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.10559708612589468, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "HOXD13"
-  },
-  "HD_HTT":
-  {
-    "id": "HD_HTT",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.16339869281045752, 0.0145032632342277, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6895, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.008380906035285832, 0.0007439173835717394, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.9515574518929341, 0.08547567815258797, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "HTT"
-  },
-  "HDL2_JPH3":
-  {
-    "id": "HDL2_JPH3",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0.014501160092807424, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0007438095073221889, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.08546483245872945, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "JPH3"
-  },
-  "OPDM1_LRP12":
-  {
-    "id": "OPDM1_LRP12",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "LRP12"
-  },
-  "FAME3_MARCHF6":
-  {
-    "id": "FAME3_MARCHF6",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6897, 52, 360, 6908, 2103, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05838978321111312, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19100893769620714, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "MARCHF6"
-  },
-  "ALS1_NIPA1":
-  {
-    "id": "ALS1_NIPA1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0.10152284263959391, 0, 0, 0.21713954834973945, 0.14258555133079848, 0, 0.1510574018126888, 0, 0],
-    "counts": [612, 6895, 52, 360, 6908, 2104, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.04765718183814036, 0.0, 0.0, 0.1274942918401005, 0.03887458713615846, 0.0, 0.0077479316128444406, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.20796972918207232, 6.457909234512961, 1.056093661065321, 0.36174810565816634, 0.4185561332617495, 3.210774116809066, 0.8806355413232516, 0.5546689609540219, 3.6112958977795095],
-    "title": "NIPA1"
-  },
-  "SCA36_NOP56":
-  {
-    "id": "SCA36_NOP56",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "NOP56"
-  },
-  "NIID_NOTCH2NLC":
-  {
-    "id": "NIID_NOTCH2NLC",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6895, 52, 360, 6902, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05840362120081246, 6.457909234512961, 1.056093661065321, 0.05835522303581345, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "NOTCH2NLC"
-  },
-  "OPML1_NUTM2B-AS1":
-  {
-    "id": "OPML1_NUTM2B-AS1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [611, 6891, 52, 358, 6902, 2103, 117, 661, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6274402119292116, 0.058431321561937796, 6.457909234512961, 1.0619213684396163, 0.05835522303581345, 0.19100893769620714, 3.210774116809066, 0.5809201676011098, 0.5546689609540219, 3.6112958977795095],
-    "title": "NUTM2B-AS1"
-  },
-  "OPMD_PABPN1":
-  {
-    "id": "OPMD_PABPN1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0.08685581933989578, 0, 0, 0.1510574018126888, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.03783246014273847, 0.0, 0.0, 0.0077479316128444406, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.19706860579386645, 0.19083907577318818, 3.210774116809066, 0.8806355413232516, 0.5546689609540219, 3.6112958977795095],
-    "title": "PABPN1"
-  },
-  "CCHS_PHOX2B":
-  {
-    "id": "CCHS_PHOX2B",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [1.6339869281045754, 0.3045243619489559, 0, 0, 1.056745801968732, 2.327790973871734, 0, 0.6042296072507553, 0.5772005772005772, 2.8846153846153846],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.8731963836696964, 0.1926573428354673, 0.0, 0.0, 0.8373976269041173, 1.7501407405176552, 0.0, 0.20664779202041794, 0.19739287160382854, 0.7907621311254991],
-    "confidence_upperbounds": [3.005621584225851, 0.4695873694164002, 6.457909234512961, 1.056093661065321, 1.3323859181918727, 3.0671835136273264, 3.210774116809066, 1.5674930745677127, 1.4979490959489725, 8.042538478931494],
-    "title": "PHOX2B"
-  },
-  "SCA12_PPP2R2B":
-  {
-    "id": "SCA12_PPP2R2B",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "PPP2R2B"
-  },
-  "HSAN-VIII_PRDM12":
-  {
-    "id": "HSAN-VIII_PRDM12",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "PRDM12"
-  },
-  "CJD_PRNP":
-  {
-    "id": "CJD_PRNP",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0.07237984944991314, 0.047505938242280284, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.028524017183089882, 0.0024367063872373813, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.17599150722239262, 0.28538853900998407, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "PRNP"
-  },
-  "FAME7_RAPGEF2":
-  {
-    "id": "FAME7_RAPGEF2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6897, 52, 360, 6909, 2097, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05838978321111312, 6.457909234512961, 1.056093661065321, 0.058306922829944305, 0.19152046726522548, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "RAPGEF2"
-  },
-  "CANVAS_RFC1":
-  {
-    "id": "CANVAS_RFC1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [611, 6897, 52, 360, 6908, 2103, 117, 662, 691, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6274402119292116, 0.05838978321111312, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19100893769620714, 3.210774116809066, 0.580061416818756, 0.5562384558357876, 3.6112958977795095],
-    "title": "RFC1"
-  },
-  "OPDM4_RILPL1":
-  {
-    "id": "OPDM4_RILPL1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6895, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05840362120081246, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "RILPL1"
-  },
-  "CCD_RUNX2":
-  {
-    "id": "CCD_RUNX2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.9803921568627451, 0.9865080516465979, 0, 0.5555555555555556, 1.664736537348002, 0.5700712589073634, 0.8547008547008548, 1.812688821752266, 1.443001443001443, 2.8846153846153846],
-    "counts": [612, 6893, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.4277991108156977, 0.773811379235116, 0.0, 0.09880008669144427, 1.3829346409261054, 0.3181557669323986, 0.04383081404426025, 1.0153834213123456, 0.7707859658672868, 0.7907621311254991],
-    "confidence_upperbounds": [2.0999217430370702, 1.2556356316025135, 6.457909234512961, 2.0247977588441857, 1.9955551888075513, 0.9902636970414649, 4.565269826796625, 3.1477537453859195, 2.645036295165834, 8.042538478931494],
-    "title": "RUNX2"
-  },
-  "FAME1_SAMD12":
-  {
-    "id": "FAME1_SAMD12",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6891, 52, 360, 6907, 2094, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.058431321561937796, 6.457909234512961, 1.056093661065321, 0.05832071289141027, 0.1917773312461455, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "SAMD12"
-  },
-  "XLMR_SOX3":
-  {
-    "XX":
-    {
+  "XLMR_SOX3": {
+    "XX": {
       "id": "XLMR_SOX3",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
       "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "SOX3_XX"
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
     },
-    "XY":
-    {
+    "XY": {
       "id": "XLMR_SOX3",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0.10198878123406425, 0, 0, 0.3681885125184094, 0.20222446916076847, 0, 0.4878048780487805, 0.2617801047120419, 0],
-      "counts": [301, 3922, 20, 321, 4074, 989, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.0, 0.034844545566446096, 0.0, 0.0, 0.2161766047124461, 0.03594311488757786, 0.0, 0.08674179711357793, 0.013426662518730077, 0.0],
-      "confidence_upperbounds": [1.260540817122589, 0.2627855361837731, 16.682097458002666, 1.1828228501457176, 0.6133195387029696, 0.749053041681649, 6.220036485072243, 1.788920075717433, 1.5167827246454328, 5.894387055227531],
-      "title": "SOX3_XY"
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3922, 20, 321, 4074, 988, 54, 410, 382, 57],
+      "values": [
+        0, 0.10198878123406425, 0, 0, 0.3681885125184094, 0.20242914979757085,
+        0, 0.4878048780487805, 0.2617801047120419, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0.034844545566446096, 0, 0, 0.2161766047124461, 0.03597950642797429,
+        0, 0.08674179711357793, 0.013426662518730077, 0
+      ],
+      "confidence_upper_bounds": [
+        1.260540817122589, 0.2627855361837731, 16.682097458002666,
+        1.1828228501457176, 0.6133195387029696, 0.7497986224455254,
+        6.220036485072243, 1.788920075717433, 1.5167827246454328,
+        5.894387055227531
+      ]
     },
-    "id": "XLMR_SOX3",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0.05828354946816262, 0, 0, 0.2180232558139535, 0.09564801530368246, 0, 0.3021148036253776, 0.1443001443001443, 0],
-    "counts": [612, 6863, 52, 360, 6880, 2091, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.01991084140603759, 0.0, 0.0, 0.12801314091843508, 0.016997432156003297, 0.0, 0.05370615099493774, 0.007401355867869128, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.15017909873470112, 6.457909234512961, 1.056093661065321, 0.36317369780589853, 0.36077340553619497, 3.210774116809066, 1.112868766297502, 0.8418017383974706, 3.6112958977795095],
-    "title": "SOX3"
+    "both": {
+      "id": "XLMR_SOX3",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6863, 52, 360, 6880, 2090, 117, 662, 693, 104],
+      "values": [
+        0, 0.05828354946816262, 0, 0, 0.2180232558139535, 0.09569377990430622,
+        0, 0.3021148036253776, 0.1443001443001443, 0
+      ],
+      "confidence_lower_bounds": [
+        0, 0.01991084140603759, 0, 0, 0.12801314091843508, 0.017005566152262175,
+        0, 0.05370615099493774, 0.007401355867869128, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.15017909873470112, 6.457909234512961,
+        1.056093661065321, 0.36317369780589853, 0.3609401604541348,
+        3.210774116809066, 1.112868766297502, 0.8418017383974706,
+        3.6112958977795095
+      ]
+    },
+    "reliable": false
   },
-  "FAME2_STARD7":
-  {
-    "id": "FAME2_STARD7",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6897, 52, 360, 6909, 2102, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05838978321111312, 6.457909234512961, 1.056093661065321, 0.058306922829944305, 0.19109398987343162, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "STARD7"
-  },
-  "SCA17_TBP":
-  {
-    "id": "SCA17_TBP",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "TBP"
-  },
-  "TOF_TBX1":
-  {
-    "id": "TOF_TBX1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.32679738562091504, 0.10152284263959391, 0, 0, 0.5500868558193398, 0.19002375296912113, 0, 0, 0, 0],
-    "counts": [612, 6895, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.058096223043940104, 0.04765718183814036, 0.0, 0.0, 0.3955239573056369, 0.06493344376057851, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [1.2027511494086687, 0.20796972918207232, 6.457909234512961, 1.056093661065321, 0.76255496838888, 0.5014762610080556, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "TBX1"
-  },
-  "FECD3_TCF4":
-  {
-    "id": "FECD3_TCF4",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [3.594771241830065, 2.0736658932714613, 1.9230769230769231, 3.3333333333333335, 6.3549507817023745, 3.9904988123515435, 0.8547008547008548, 3.474320241691843, 3.0303030303030303, 4.807692307692308],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [2.3419305942192703, 1.7598366595526536, 0.0985923165515654, 1.8754706187118924, 5.795640102753076, 3.2237033909178967, 0.04383081404426025, 2.290798574298985, 1.916446947929408, 1.9132268292768158],
-    "confidence_upperbounds": [5.370228677079501, 2.446904440502109, 10.244332921927223, 5.786269430053519, 6.953930033094478, 4.910636772270513, 4.565269826796625, 5.187220820937397, 4.595857734524972, 10.905717848429978],
-    "title": "TCF4"
-  },
-  "FAME6_TNRC6A":
-  {
-    "id": "FAME6_TNRC6A",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6909, 2098, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.058306922829944305, 0.19143500917933343, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "TNRC6A"
-  },
-  "HMNR7_VWA1":
-  {
-    "id": "HMNR7_VWA1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [2.6143790849673203, 0.3190255220417633, 0, 0, 0.390851187029531, 4.133016627078385, 0, 0, 0, 1.9230769230769231],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [1.5832362795041677, 0.20793956981203995, 0.0, 0.0, 0.26545588639162876, 3.341699926471188, 0.0, 0.0, 0.0, 0.3427601671968367],
-    "confidence_upperbounds": [4.2219654634676305, 0.4833890355717739, 6.457909234512961, 1.056093661065321, 0.5693947152666117, 5.087177875305857, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 6.598830830498273],
-    "title": "VWA1"
-  },
-  "DBQD2_XYLT1":
-  {
-    "id": "DBQD2_XYLT1",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05839670121277325, 6.457909234512961, 1.056093661065321, 0.05831381689826813, 0.19083907577318818, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "XYLT1"
-  },
-  "FAME4_YEATS2":
-  {
-    "id": "FAME4_YEATS2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    "counts": [612, 6890, 52, 360, 6909, 2103, 117, 662, 692, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.05843825165560828, 6.457909234512961, 1.056093661065321, 0.058306922829944305, 0.19100893769620714, 3.210774116809066, 0.580061416818756, 0.5554525747663754, 3.6112958977795095],
-    "title": "YEATS2"
-  },
-  "HPE5_ZIC2":
-  {
-    "id": "HPE5_ZIC2",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0.49019607843137253, 0.20301624129930393, 0, 0, 0.6948465547191662, 0.38004750593824227, 0, 0, 0.1443001443001443, 0],
-    "counts": [612, 6896, 52, 360, 6908, 2105, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.1337390196569911, 0.11757392051875191, 0.0, 0.0, 0.5186138302635641, 0.17880665574320923, 0.0, 0.0, 0.007401355867869128, 0.0],
-    "confidence_upperbounds": [1.4496873128399737, 0.33861881391668724, 6.457909234512961, 1.056093661065321, 0.9283262944608791, 0.7632167820774235, 3.210774116809066, 0.580061416818756, 0.8418017383974706, 3.6112958977795095],
-    "title": "ZIC2"
-  },
-  "VACTERLX_ZIC3":
-  {
-    "XX":
-    {
+  "VACTERLX_ZIC3": {
+    "XX": {
       "id": "VACTERLX_ZIC3",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
       "counts": [311, 2941, 32, 39, 2806, 1102, 63, 252, 311, 47],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.2204333057620216, 0.14006618347596145, 10.460931523534367, 8.595221611616278, 0.1462170639871151, 0.35338495953330457, 5.954348689658154, 1.4922870741313126, 1.2204333057620216, 7.140700922294211],
-      "title": "ZIC3_XX"
+      "values": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+      "confidence_upper_bounds": [
+        1.2204333057620216, 0.14006618347596145, 10.460931523534367,
+        8.595221611616278, 0.1462170639871151, 0.35338495953330457,
+        5.954348689658154, 1.4922870741313126, 1.2204333057620216,
+        7.140700922294211
+      ]
     },
-    "XY":
-    {
+    "XY": {
       "id": "VACTERLX_ZIC3",
-      "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [301, 3938, 20, 321, 4091, 995, 54, 410, 382, 57],
       "values": [0, 0, 0, 0, 0.09777560498655585, 0, 0, 0, 0, 0],
-      "counts": [301, 3938, 20, 321, 4091, 996, 54, 410, 382, 57],
-      "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.03340482297502289, 0.0, 0.0, 0.0, 0.0, 0.0],
-      "confidence_upperbounds": [1.260540817122589, 0.10096659831607603, 16.682097458002666, 1.1828228501457176, 0.2519306209931205, 0.3896856094588401, 6.220036485072243, 0.9288681332954924, 0.9960138516718677, 5.894387055227531],
-      "title": "ZIC3_XY"
+      "confidence_lower_bounds": [
+        0, 0, 0, 0, 0.03340482297502289, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        1.260540817122589, 0.10096659831607603, 16.682097458002666,
+        1.1828228501457176, 0.2519306209931205, 0.39006488620677876,
+        6.220036485072243, 0.9288681332954924, 0.9960138516718677,
+        5.894387055227531 
+      ]
     },
-    "id": "VACTERLX_ZIC3",
-    "labels": ["Admixed American", "African/African American", "Amish", "Ashkenazi Jewish", "European (non Finnish)", "Finnish", "Middle Eastern", "South Asian", "East Asian", "Others"],
-    "values": [0, 0, 0, 0, 0.05799623024503408, 0, 0, 0, 0, 0],
-    "counts": [612, 6879, 52, 360, 6897, 2098, 117, 662, 693, 104],
-    "confidence_lowerbounds": [0.0, 0.0, 0.0, 0.0, 0.019812675724180728, 0.0, 0.0, 0.0, 0.0, 0.0],
-    "confidence_upperbounds": [0.6264353486568519, 0.058514615636193354, 6.457909234512961, 1.056093661065321, 0.14943879666531387, 0.19143500917933343, 3.210774116809066, 0.580061416818756, 0.5546689609540219, 3.6112958977795095],
-    "title": "ZIC3"
+    "both": {
+      "id": "VACTERLX_ZIC3",
+      "labels": [
+        "Admixed American",
+        "African/African American",
+        "Amish",
+        "Ashkenazi Jewish",
+        "European (non Finnish)",
+        "Finnish",
+        "Middle Eastern",
+        "South Asian",
+        "East Asian",
+        "Others"
+      ],
+      "counts": [612, 6879, 52, 360, 6897, 2097, 117, 662, 693, 104],
+      "values": [0, 0, 0, 0, 0.05799623024503408, 0, 0, 0, 0, 0],
+      "confidence_lower_bounds": [
+        0, 0, 0, 0, 0.019812675724180728, 0, 0, 0, 0, 0
+      ],
+      "confidence_upper_bounds": [
+        0.6264353486568519, 0.058514615636193354, 6.457909234512961,
+        1.056093661065321, 0.14943879666531387, 0.19152046726522548,
+        3.210774116809066, 0.580061416818756, 0.5546689609540219,
+        3.6112958977795095
+      ]
+    },
+    "reliable": true
   }
 }


### PR DESCRIPTION
#123 appears to have introduced a bug, so gnomAD plots aren't showing. Attempting to fix this by reverting to the previous working version then will do a proper fix.