### PR TITLE
Add PR templates for general and Literature PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+
+Summarize the changes
+
+Fixes: # **Link to any relevant issues and/or discussions**
+
+## Major Changes
+
+- New locus or major change to existing locus e.g. pathogenic threshold, coordinate
+- New feature
+- New data field
+
+## Minor Changes
+
+- Minor change to existing locus e.g. new citation
+- Bug or gramatical error fix
+
+## Checklist
+
+- [ ] All changes are well summarized
+- [ ] Check all tests pass
+- [ ] Check that the website preview looks good
+- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
+- [ ] Ask someone to review this PR

--- a/.github/PULL_REQUEST_TEMPLATE/literature_PR_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/literature_PR_template.md
@@ -1,0 +1,27 @@
+**Please edit this description as you work on this PR**
+
+## Description
+
+This PR introduces changes from automated literature retrieval followed by manual curation.
+
+Fixes: # **Link to any relevant issues and/or discussions**
+
+## Major Changes
+
+- New locus or major change to existing locus e.g. pathogenic threshold, coordinate
+
+## Minor Changes
+
+- Minor change to existing locus e.g. new citation
+
+## Checklist
+
+- [ ] Check I've included all literature since the last "Literature Update" PR (may need to diff against an earlier version)
+- [ ] Check for updates to existing loci
+- [ ] Check for potential new loci
+- [ ] Add any changes to `STRchive-loci.json` as commits to this branch/PR
+- [ ] If anything needs to be discussed further before adding to STRchive, add it to [Discussions](https://github.com/dashnowlab/STRchive/discussions)
+- [ ] Check all tests pass e.g. the website built
+- [ ] Check that the website preview looks good
+- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
+- [ ] Ask someone to review this PR

--- a/.github/workflows/update-loci.yaml
+++ b/.github/workflows/update-loci.yaml
@@ -72,7 +72,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           branch: update-data
-          title: Update data
+          title: Update Literature
+          body-path: .github/literature_PR_template.md
 
       - name: Commit updated files to current pull request
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/update-loci.yaml
+++ b/.github/workflows/update-loci.yaml
@@ -73,7 +73,7 @@ jobs:
         with:
           branch: update-data
           title: Update Literature
-          body-path: .github/literature_PR_template.md
+          body-path: .github/PULL_REQUEST_TEMPLATE/literature_PR_template.md
 
       - name: Commit updated files to current pull request
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
`.github/PULL_REQUEST_TEMPLATE.md` - should apply by default to all new PRs created on GitHub
`.github/PULL_REQUEST_TEMPLATE/literature_PR_template.md` - for auto PRs created by GitHub Actions