### PR TITLE
add 1 to start position in UCSC links

### DIFF
--- a/site/src/data/derived.js
+++ b/site/src/data/derived.js
@@ -13,8 +13,11 @@ export const deriveLocus = (locus, loci, citations) => {
 
   /** construct full position strings */
   for (const assembly of ["hg19", "hg38", "t2t"])
-    locus[`position_${assembly}`] =
+    locus[`position_base0_${assembly}`] =
       `${locus.chrom}:${locus[`start_${assembly}`]}-${locus[`stop_${assembly}`]}`;
+  for (const assembly of ["hg19", "hg38", "t2t"])
+    locus[`position_base1_${assembly}`] =
+      `${locus.chrom}:${locus[`start_${assembly}`] + 1}-${locus[`stop_${assembly}`]}`;
 
   /** make prevalence fraction */
   if (locus.prevalence)

--- a/site/src/loci/Table.jsx
+++ b/site/src/loci/Table.jsx
@@ -53,7 +53,7 @@ const cols = [
     name: "Description",
   },
   {
-    key: "position_hg38",
+    key: "position_base0_hg38",
     name: "Position hg38",
     render: (cell) => (
       <Link

--- a/site/src/loci/Table.jsx
+++ b/site/src/loci/Table.jsx
@@ -55,9 +55,9 @@ const cols = [
   {
     key: "position_base0_hg38",
     name: "Position hg38",
-    render: (cell) => (
+    render: (cell, row) => (
       <Link
-        to={`https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=${cell}`}
+        to={`https://genome.ucsc.edu/cgi-bin/hgTracks?db=hg38&position=${row.position_base1_hg38}`}
       >
         {cell}
       </Link>

--- a/site/src/pages/loci/[id].astro
+++ b/site/src/pages/loci/[id].astro
@@ -251,9 +251,9 @@ const blame = getJsonBlame(
           <div class="box">
             <div>{assembly}</div>
             <Link
-              to={`http://genome.ucsc.edu/cgi-bin/hgTracks?db=${db}&position=${locus[`position_${assembly}`]}`}
+              to={`http://genome.ucsc.edu/cgi-bin/hgTracks?db=${db}&position=${locus[`position_base1_${assembly}`]}`}
             >
-              {locus[`position_${assembly}`]}
+              {locus[`position_base0_${assembly}`]}
             </Link>
           </div>
         ))


### PR DESCRIPTION
## Description

Partial fix the UCSC link bug. This works on the locus pages, but I can't figure out how to fix it in `site/src/loci/Table.jsx` as well.

Fixes: #149 

## Minor Changes

- Add 1 to start position when creating UCSC genome-browser links

## Checklist

- [ ] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR