### PR TITLE
Typo STRchive-loci.json

### DIFF
--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -2281,7 +2281,7 @@
   "mechanism": "GoF/LoF",
   "mechanism_detail": "While the primary pathogenic mechanism is gain of function of the protein product, pathogenesis is complex and multifactorial [@pmid:27940602].",
   "source": [],
-  "details": "27-35 motifs are unstable/premutations, while 36-39 motifs are associated with reduced penetrance and mild phenotypes [@pmid:39572770]. >60 motifs assocated with onset age <20 years [@genereviews:NBK1305]. Only CAG expansions are considered pathogenic, but interruptions impact pathogenicity (e.g. CAA) [@pmid:35245110]. Only fathers with premutations are considered at risk of transmitting pathogenic alleles [@pmid:19507258]. CAG repeats in the non-HD range (>= 21 repeats) may modulate psychiatric disease risk in an age-dependent manner [@pmid:39572770]",
+  "details": "27-35 motifs are unstable/premutations, while 36-39 motifs are associated with reduced penetrance and mild phenotypes [@pmid:39572770]. >60 motifs associated with onset age <20 years [@genereviews:NBK1305]. Only CAG expansions are considered pathogenic, but interruptions impact pathogenicity (e.g. CAA) [@pmid:35245110]. Only fathers with premutations are considered at risk of transmitting pathogenic alleles [@pmid:19507258]. CAG repeats in the non-HD range (>= 21 repeats) may modulate psychiatric disease risk in an age-dependent manner [@pmid:39572770]",
   "omim": ["143100"],
   "prevalence": "1/10000",
   "prevalence_details": "6.5-15/100,000 [@pmid:29100084]. 9.71-17:100,000 (European) vs. 0.1-2/100,000 (African), as many as 1 in 400 have reduced penetrance (0.2-2% for 36-38 CAG) HTT alleles [@genereviews:NBK1305]. Found across ethnicities/ancestries, with population-dependent prevalence [@genereviews:NBK1305].",


### PR DESCRIPTION
noticed a typo: assocated rather than associated

## Description

Summarize the changes

Fixes: # 1

## Major Changes
None

## Minor Changes

- little typo: assocated vs associated

## Checklist

- [ x ] All changes are well summarized
- [ x ] Check all tests pass
- [ x ] Check that the website preview looks good
- [ x ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ x ] Ask someone to review this PR