### PR TITLE
atarva catalog - not skipping the internal repeats

### DIFF
--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -1354,7 +1354,7 @@
   "locus_structure": [
   {
     "motif": "AAAAT",
-    "count": 7,
+    "count": 15,
     "type": "internal_repeat"
   },
   {

--- a/scripts/make-catalog.py
+++ b/scripts/make-catalog.py
@@ -313,7 +313,7 @@ def atarva_catalog(row, genome = 'hg38'):
                 bed_string += f"{row['chrom']}\t{start}\t{stop}\t{motif}\t{motif_len}\t{this_id}\n"
             elif struct_dict['type'] == 'interruption' or struct_dict['type'] == 'internal_repeat':
                 # interruptions and internal repeats are not included in the structure
-                continue
+                bed_string += f"{row['chrom']}\t{start}\t{stop}\t{motif}\t{motif_len}\t{this_id}\n"
             else:
                 # this is a flank repeat
                 bed_string += f"{row['chrom']}\t{start}\t{stop}\t{motif}\t{motif_len}\t{this_id}_flank\n"


### PR DESCRIPTION
## Major Changes
- Removed the `continue` statement for not adding internal repeats in atarva catalog
- SCA37_DAB1 locus seems to have wrong number of `count` (repeat units) in the locus structure in the STRchive-loci.json. I was originally 7 but the locus has 15 in hg38.