### PR TITLE
Update DAB1/SCA37 criTRia curation

### DIFF
--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -1429,7 +1429,7 @@
   "id": "SCA37_DAB1",
   "disease_id": "SCA37",
   "gene": "DAB1",
-  "evidence": ["Definitive"],
+  "evidence": ["Strong"],
   "chrom": "chr1",
   "start_hg38": 57367043,
   "stop_hg38": 57367121,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2116,154 +2116,154 @@
   "Gene": "DAB1",
   "Locus_ID": "SCA37_DAB1",
   "Inheritance": "AD",
-  "Curator": "Laurel Hiatt",
-  "Date": "08/18/2025",
-  "Description": null,
+  "Curator": "Laurel Hiatt, Elbay Aliyev",
+  "Date": "8/18/25",
+  "Manual_evidence_level": "Definitive",
+  "Description": "Spinocerebellar ataxia type 37 (SCA37) is an autosomal dominant, generally pure cerebellar ataxia associated with an unstable intronic ATTTC pentanucleotide insertion in the non-coding/regulatory region of DAB1. Reported pathogenic alleles place an ATTTC insertion within a polymorphic ATTTT tract, whereas ATTTT-only alleles are non-pathogenic. Available evidence includes familial segregation and shared haplotypes in Portuguese and Spanish kindreds, absence of the ATTTC mutation from control/healthy relatives, repeat-size effects on age at onset, DAB1 transcript dysregulation/RNA switch in SCA37 cerebellum, AUUUC RNA aggregation in transfected human cells, and AUUUC repeat toxicity in zebrafish embryos.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
-  "Manual_evidence_level": "Definitive",
-  "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 3.0,
-    "Citation": "pmid:30284037",
-    "Evidence detail": "probands:2",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2019-02-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1.0,
-    "Citation": "pmid:29939198",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2018-07-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:30284037",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-02-01"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 6.0,
-    "Citation": "pmid:29939198",
-    "Evidence detail": null,
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2018-07-01"]
-  }],
-  "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 1.0,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Cell culture",
-    "Score": 1.0,
-    "Citation": "pmid:28686858",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
-  }],
-  "category_summary":
-  {
-    "Singular Evidence": 3.0,
+  "category_summary": {
     "Collective Evidence": 2.5,
-    "Statistics": 6.0,
-    "Function": 2.0,
+    "Function": 2,
     "Functional Alteration": 1.5,
-    "Models": 3.0,
+    "Models": 3,
+    "Singular Evidence": 6,
+    "Statistics": 6,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
-    "Genetic Evidence": 11.5
+    "Genetic Evidence": 12
   },
-  "total_score": 17.5,
+  "total_score": 18,
+  "classification": "Definitive",
   "publication_count": 3,
   "publication_interval_years": 1.57,
-  "classification": "Definitive"
+  "genetic_evidence_details": [
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:28686858; pmid:29939198",
+      "Evidence detail": "PMID:28686858 identified the DAB1 ATTTC insertion in three large Portuguese SCA37 families and three additional pedigrees sharing the disease haplotype, with 35 affected individuals from the initial three kindreds and six affected individuals from the additional pedigrees. PMID:29939198 reported four Spanish SCA37 families with 25 affected individuals and seven at-risk asymptomatic carriers carrying the ATTTC repeat mutation.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_date": "2019-02-01 00:00:00"
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1.0,
+      "Citation": "pmid:29939198",
+      "Evidence detail": "In four Spanish SCA37 kindreds, 25 affected and seven at-risk asymptomatic carriers had ATTTC insertions of 46–71 and 49–62 repeats, respectively; in males, larger repeat size correlated with earlier onset (r = 0.96, p < 0.0001), with small repeat increases observed in transmissions.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_date": "2018-07-01 00:00:00"
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:28686858; pmid:29939198",
+      "Evidence detail": "PMID:28686858 mapped SCA37 to chromosome 1p32.2 in three Portuguese families, with maximum multipoint LOD scores of 5.1, 4.4, and 2.2, and showed that the DAB1 ATTTC insertion segregated with disease in all studied families. PMID:29939198 independently showed segregation of the DAB1 ATTTC mutation with disease in four Spanish SCA37 families.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_date": "2019-02-01 00:00:00"
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 6.0,
+      "Citation": "pmid:29939198",
+      "Evidence detail": "The ATTTC mutation was identified in SCA37 families and was absent from 28 healthy relatives studied; the study also screened a cohort of ataxia patients to identify additional SCA37 pedigrees sharing the DAB1-region haplotype.",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_date": "2018-07-01 00:00:00"
+    }
+  ],
+  "experimental_evidence_details": [
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "Gene-level support: DAB1 is a reelin signal transducer required for accurate neuronal positioning in cerebellar, hippocampal, and cortical development; DAB1 transcripts spanning the repeat region encode the functional PID/PTB receptor-binding domain.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2017-07-06 00:00:00"
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "Gene-level support: DAB1 functions in the reelin pathway through an N-terminal PID/PTB domain involved in reelin receptor binding; the paper does not directly show TR-specific disruption of protein interactions.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2017-07-06 00:00:00"
+    },
+    {
+      "Evidence type": "Regulatory Impact",
+      "Score": 1.0,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "The ATTTC insertion lies within 5′ UTR introns of DAB1 transcripts expressed in adult cerebellum; transcript analyses showed alternative promoter usage and cerebellar-enriched DAB1 variants spanning the repeat region.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2017-07-06 00:00:00"
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2017-07-06 00:00:00"
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "HEK293T cells transfected with the pathogenic ins(ATTTC)58 construct formed nuclear AUUUC RNA aggregates by RNA FISH; normal ATTTT-repeat constructs did not, and RNase treatment abolished the signal.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_date": "2017-07-06 00:00:00"
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "Zebrafish embryos injected with ins(AUUUC)58 RNA showed increased 24 hpf lethality (58.79% versus 14.40–21.51% controls) and markedly reduced normal development (7.76% versus 77.52–85.37% controls).",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_date": "2017-07-06 00:00:00"
+    },
+    {
+      "Evidence type": "Cell culture",
+      "Score": 1.0,
+      "Citation": "pmid:28686858",
+      "Evidence detail": "",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2017-07-06 00:00:00"
+    }
+  ]
 },
 {
   "Disease_ID": "DMD",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2132,7 +2132,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 6,
     "category_max_score": 6,
-    "publication_date": "2019-02-01 00:00:00",
     "publication_dates": ["2017-07-06", "2018-07-01"]
   },
   {
@@ -2144,7 +2143,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 2,
     "category_max_score": 3,
-    "publication_date": "2018-07-01 00:00:00",
     "publication_dates": ["2018-07-01"]
   },
   {
@@ -2156,7 +2154,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 3,
     "category_max_score": 3,
-    "publication_date": "2019-02-01 00:00:00",
     "publication_dates": ["2017-07-06", "2018-07-01"]
   },
   {
@@ -2168,7 +2165,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 12,
     "category_max_score": 12,
-    "publication_date": "2018-07-01 00:00:00",
     "publication_dates": ["2018-07-01"]
   }],
   "experimental_evidence_details": [
@@ -2181,7 +2177,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   },
   {
@@ -2193,7 +2188,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   },
   {
@@ -2205,7 +2199,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   },
   {
@@ -2217,7 +2210,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   },
   {
@@ -2229,7 +2221,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 1,
     "category_max_score": 2,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   },
   {
@@ -2241,7 +2232,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,
     "category_max_score": 4,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   },
   {
@@ -2253,7 +2243,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": "2017-07-06 00:00:00",
     "publication_dates": ["2017-07-06"]
   }],
   "category_summary":

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2121,7 +2121,7 @@
   "Description": "Spinocerebellar ataxia type 37 (SCA37) is an autosomal dominant, generally pure cerebellar ataxia associated with an unstable intronic ATTTC pentanucleotide insertion in the non-coding/regulatory region of DAB1. Reported pathogenic alleles place an ATTTC insertion within a polymorphic ATTTT tract, whereas ATTTT-only alleles are non-pathogenic. Available evidence includes familial segregation and shared haplotypes in Portuguese and Spanish kindreds, absence of the ATTTC mutation from control/healthy relatives, repeat-size effects on age at onset, DAB1 transcript dysregulation/RNA switch in SCA37 cerebellum, AUUUC RNA aggregation in transfected human cells, and AUUUC repeat toxicity in zebrafish embryos.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
-  "Manual_evidence_level": "Definitive",
+  "Manual_evidence_level": null,
   "genetic_evidence_details": [
   {
     "Evidence type": "Probands",
@@ -2158,9 +2158,9 @@
   },
   {
     "Evidence type": "Case-control data",
-    "Score": 6.0,
+    "Score": 0.0,
     "Citation": "pmid:29939198",
-    "Evidence detail": "The ATTTC mutation was identified in SCA37 families and was absent from 28 healthy relatives studied; the study also screened a cohort of ataxia patients to identify additional SCA37 pedigrees sharing the DAB1-region haplotype.",
+    "Evidence detail": "The ATTTC mutation was identified in SCA37 families and was absent from 28 healthy relatives studied; the study also screened a cohort of ataxia patients to identify additional SCA37 pedigrees sharing the DAB1-region haplotype. No additional score was awarded as this study has been scored under other evidence types.",
     "evidence_category": "Statistics",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 12,
@@ -2172,7 +2172,7 @@
     "Evidence type": "Biochemical function",
     "Score": 0.5,
     "Citation": "pmid:28686858",
-    "Evidence detail": "Gene-level support: DAB1 is a reelin signal transducer required for accurate neuronal positioning in cerebellar, hippocampal, and cortical development; DAB1 transcripts spanning the repeat region encode the functional PID/PTB receptor-binding domain.",
+    "Evidence detail": "Gene-level support: DAB1 is a reelin signal transducer required for accurate neuronal positioning in cerebellar, hippocampal, and cortical development; DAB1 transcripts spanning the repeat region encode the functional PID/PTB receptor-binding domain. This evidence supports the role of the gene.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
@@ -2183,7 +2183,7 @@
     "Evidence type": "Protein interaction",
     "Score": 0.5,
     "Citation": "pmid:28686858",
-    "Evidence detail": "Gene-level support: DAB1 functions in the reelin pathway through an N-terminal PID/PTB domain involved in reelin receptor binding; the paper does not directly show TR-specific disruption of protein interactions.",
+    "Evidence detail": "Gene-level support: DAB1 functions in the reelin pathway through an N-terminal PID/PTB domain involved in reelin receptor binding; the paper does not directly show TR-specific disruption of protein interactions. This evidence supports the role of the gene.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
@@ -2203,9 +2203,9 @@
   },
   {
     "Evidence type": "Patient cells",
-    "Score": 1.0,
+    "Score": 0.0,
     "Citation": "pmid:28686858",
-    "Evidence detail": "",
+    "Evidence detail": "Patient fibrobroblasts were used in this study, however the experiment is already scored elsewhere. No score was awarded for this evidence.",
     "evidence_category": "Functional Alteration",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
@@ -2233,37 +2233,26 @@
     "evidence_max_score": 4,
     "category_max_score": 4,
     "publication_dates": ["2017-07-06"]
-  },
-  {
-    "Evidence type": "Cell culture",
-    "Score": 1.0,
-    "Citation": "pmid:28686858",
-    "Evidence detail": "",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-07-06"]
   }],
   "category_summary":
   {
     "Singular Evidence": 6.0,
     "Collective Evidence": 2.5,
-    "Statistics": 6.0,
+    "Statistics": 0.0,
     "Function": 2.0,
-    "Functional Alteration": 1.5,
-    "Models": 3.0,
+    "Functional Alteration": 0.5,
+    "Models": 2.0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 6,
-    "Genetic Evidence": 12
+    "Experimental Evidence": 4.5,
+    "Genetic Evidence": 8.5
   },
-  "total_score": 18,
+  "total_score": 13.0,
   "publication_count": 2,
   "publication_interval_years": 0.99,
-  "classification": "Definitive"
+  "classification": "Strong"
 },
 {
   "Disease_ID": "DMD",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2117,153 +2117,164 @@
   "Locus_ID": "SCA37_DAB1",
   "Inheritance": "AD",
   "Curator": "Laurel Hiatt, Elbay Aliyev",
-  "Date": "8/18/25",
-  "Manual_evidence_level": "Definitive",
+  "Date": "08/18/2025",
   "Description": "Spinocerebellar ataxia type 37 (SCA37) is an autosomal dominant, generally pure cerebellar ataxia associated with an unstable intronic ATTTC pentanucleotide insertion in the non-coding/regulatory region of DAB1. Reported pathogenic alleles place an ATTTC insertion within a polymorphic ATTTT tract, whereas ATTTT-only alleles are non-pathogenic. Available evidence includes familial segregation and shared haplotypes in Portuguese and Spanish kindreds, absence of the ATTTC mutation from control/healthy relatives, repeat-size effects on age at onset, DAB1 transcript dysregulation/RNA switch in SCA37 cerebellum, AUUUC RNA aggregation in transfected human cells, and AUUUC repeat toxicity in zebrafish embryos.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
-  "category_summary": {
+  "Manual_evidence_level": "Definitive",
+  "genetic_evidence_details": [
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:28686858; pmid:29939198",
+    "Evidence detail": "PMID:28686858 identified the DAB1 ATTTC insertion in three large Portuguese SCA37 families and three additional pedigrees sharing the disease haplotype, with 35 affected individuals from the initial three kindreds and six affected individuals from the additional pedigrees. PMID:29939198 reported four Spanish SCA37 families with 25 affected individuals and seven at-risk asymptomatic carriers carrying the ATTTC repeat mutation.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_date": "2019-02-01 00:00:00",
+    "publication_dates": ["2017-07-06", "2018-07-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1.0,
+    "Citation": "pmid:29939198",
+    "Evidence detail": "In four Spanish SCA37 kindreds, 25 affected and seven at-risk asymptomatic carriers had ATTTC insertions of 46–71 and 49–62 repeats, respectively; in males, larger repeat size correlated with earlier onset (r = 0.96, p < 0.0001), with small repeat increases observed in transmissions.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_date": "2018-07-01 00:00:00",
+    "publication_dates": ["2018-07-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:28686858; pmid:29939198",
+    "Evidence detail": "PMID:28686858 mapped SCA37 to chromosome 1p32.2 in three Portuguese families, with maximum multipoint LOD scores of 5.1, 4.4, and 2.2, and showed that the DAB1 ATTTC insertion segregated with disease in all studied families. PMID:29939198 independently showed segregation of the DAB1 ATTTC mutation with disease in four Spanish SCA37 families.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_date": "2019-02-01 00:00:00",
+    "publication_dates": ["2017-07-06", "2018-07-01"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 6.0,
+    "Citation": "pmid:29939198",
+    "Evidence detail": "The ATTTC mutation was identified in SCA37 families and was absent from 28 healthy relatives studied; the study also screened a cohort of ataxia patients to identify additional SCA37 pedigrees sharing the DAB1-region haplotype.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_date": "2018-07-01 00:00:00",
+    "publication_dates": ["2018-07-01"]
+  }],
+  "experimental_evidence_details": [
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "Gene-level support: DAB1 is a reelin signal transducer required for accurate neuronal positioning in cerebellar, hippocampal, and cortical development; DAB1 transcripts spanning the repeat region encode the functional PID/PTB receptor-binding domain.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "Gene-level support: DAB1 functions in the reelin pathway through an N-terminal PID/PTB domain involved in reelin receptor binding; the paper does not directly show TR-specific disruption of protein interactions.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 1.0,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "The ATTTC insertion lies within 5′ UTR introns of DAB1 transcripts expressed in adult cerebellum; transcript analyses showed alternative promoter usage and cerebellar-enriched DAB1 variants spanning the repeat region.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "HEK293T cells transfected with the pathogenic ins(ATTTC)58 construct formed nuclear AUUUC RNA aggregates by RNA FISH; normal ATTTT-repeat constructs did not, and RNase treatment abolished the signal.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "Zebrafish embryos injected with ins(AUUUC)58 RNA showed increased 24 hpf lethality (58.79% versus 14.40–21.51% controls) and markedly reduced normal development (7.76% versus 77.52–85.37% controls).",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  },
+  {
+    "Evidence type": "Cell culture",
+    "Score": 1.0,
+    "Citation": "pmid:28686858",
+    "Evidence detail": "",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": "2017-07-06 00:00:00",
+    "publication_dates": ["2017-07-06"]
+  }],
+  "category_summary":
+  {
+    "Singular Evidence": 6.0,
     "Collective Evidence": 2.5,
-    "Function": 2,
+    "Statistics": 6.0,
+    "Function": 2.0,
     "Functional Alteration": 1.5,
-    "Models": 3,
-    "Singular Evidence": 6,
-    "Statistics": 6,
+    "Models": 3.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },
   "total_score": 18,
-  "classification": "Definitive",
-  "publication_count": 3,
-  "publication_interval_years": 1.57,
-  "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:28686858; pmid:29939198",
-      "Evidence detail": "PMID:28686858 identified the DAB1 ATTTC insertion in three large Portuguese SCA37 families and three additional pedigrees sharing the disease haplotype, with 35 affected individuals from the initial three kindreds and six affected individuals from the additional pedigrees. PMID:29939198 reported four Spanish SCA37 families with 25 affected individuals and seven at-risk asymptomatic carriers carrying the ATTTC repeat mutation.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_date": "2019-02-01 00:00:00"
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1.0,
-      "Citation": "pmid:29939198",
-      "Evidence detail": "In four Spanish SCA37 kindreds, 25 affected and seven at-risk asymptomatic carriers had ATTTC insertions of 46–71 and 49–62 repeats, respectively; in males, larger repeat size correlated with earlier onset (r = 0.96, p < 0.0001), with small repeat increases observed in transmissions.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_date": "2018-07-01 00:00:00"
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:28686858; pmid:29939198",
-      "Evidence detail": "PMID:28686858 mapped SCA37 to chromosome 1p32.2 in three Portuguese families, with maximum multipoint LOD scores of 5.1, 4.4, and 2.2, and showed that the DAB1 ATTTC insertion segregated with disease in all studied families. PMID:29939198 independently showed segregation of the DAB1 ATTTC mutation with disease in four Spanish SCA37 families.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_date": "2019-02-01 00:00:00"
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 6.0,
-      "Citation": "pmid:29939198",
-      "Evidence detail": "The ATTTC mutation was identified in SCA37 families and was absent from 28 healthy relatives studied; the study also screened a cohort of ataxia patients to identify additional SCA37 pedigrees sharing the DAB1-region haplotype.",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_date": "2018-07-01 00:00:00"
-    }
-  ],
-  "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "Gene-level support: DAB1 is a reelin signal transducer required for accurate neuronal positioning in cerebellar, hippocampal, and cortical development; DAB1 transcripts spanning the repeat region encode the functional PID/PTB receptor-binding domain.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2017-07-06 00:00:00"
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "Gene-level support: DAB1 functions in the reelin pathway through an N-terminal PID/PTB domain involved in reelin receptor binding; the paper does not directly show TR-specific disruption of protein interactions.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2017-07-06 00:00:00"
-    },
-    {
-      "Evidence type": "Regulatory Impact",
-      "Score": 1.0,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "The ATTTC insertion lies within 5′ UTR introns of DAB1 transcripts expressed in adult cerebellum; transcript analyses showed alternative promoter usage and cerebellar-enriched DAB1 variants spanning the repeat region.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2017-07-06 00:00:00"
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2017-07-06 00:00:00"
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "HEK293T cells transfected with the pathogenic ins(ATTTC)58 construct formed nuclear AUUUC RNA aggregates by RNA FISH; normal ATTTT-repeat constructs did not, and RNase treatment abolished the signal.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_date": "2017-07-06 00:00:00"
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "Zebrafish embryos injected with ins(AUUUC)58 RNA showed increased 24 hpf lethality (58.79% versus 14.40–21.51% controls) and markedly reduced normal development (7.76% versus 77.52–85.37% controls).",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_date": "2017-07-06 00:00:00"
-    },
-    {
-      "Evidence type": "Cell culture",
-      "Score": 1.0,
-      "Citation": "pmid:28686858",
-      "Evidence detail": "",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2017-07-06 00:00:00"
-    }
-  ]
+  "publication_count": 2,
+  "publication_interval_years": 0.99,
+  "classification": "Definitive"
 },
 {
   "Disease_ID": "DMD",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2116,7 +2116,7 @@
   "Gene": "DAB1",
   "Locus_ID": "SCA37_DAB1",
   "Inheritance": "AD",
-  "Curator": "Laurel Hiatt, Elbay Aliyev",
+  "Curator": "Laurel Hiatt, Elbay Aliyev, Harriet Dashnow",
   "Date": "08/18/2025",
   "Description": "Spinocerebellar ataxia type 37 (SCA37) is an autosomal dominant, generally pure cerebellar ataxia associated with an unstable intronic ATTTC pentanucleotide insertion in the non-coding/regulatory region of DAB1. Reported pathogenic alleles place an ATTTC insertion within a polymorphic ATTTT tract, whereas ATTTT-only alleles are non-pathogenic. Available evidence includes familial segregation and shared haplotypes in Portuguese and Spanish kindreds, absence of the ATTTC mutation from control/healthy relatives, repeat-size effects on age at onset, DAB1 transcript dysregulation/RNA switch in SCA37 cerebellum, AUUUC RNA aggregation in transfected human cells, and AUUUC repeat toxicity in zebrafish embryos.",
   "Source": "criTRia",


### PR DESCRIPTION
## Description

Updated the DAB1/SCA37 criTRia curation entry to improve evidence details and citation support. The main change was replacing review-based support for proband and segregation evidence with primary literature from PMID:28686858 and PMID:29939198. The proband evidence score was updated according to the criTRia SOP maximum for Singular Evidence, and the overall genetic/total scores were capped appropriately.

Fixes: # 

## Major Changes

- Updated DAB1/SCA37 proband evidence to cite primary sources: PMID:28686858 and PMID:29939198.
- Updated DAB1/SCA37 segregation evidence to cite primary sources: PMID:28686858 and PMID:29939198.
- Revised proband evidence score from 3.0 to 6.0 based on multiple unrelated SCA37 families reported across the Portuguese discovery and Spanish replication studies.
- Updated summary scores to reflect SOP-based scoring caps:
  - Singular Evidence: 3.0 → 6.0
  - Genetic Evidence: 11.5 → 12.0
  - Total score: 17.5 → 18.0
- Classification remains Definitive.

## Minor Changes

- Added clearer, more evidence-specific details for DAB1/SCA37 proband and segregation rows.
- Replaced review-based PMID:30284037 support with primary-source citations where appropriate.
- Updated the root-level Description to summarize the DAB1 ATTTC repeat expansion, familial segregation, repeat-size effects, functional evidence, and model evidence.
- Added curator-review notes for evidence rows where the cited data may overlap or may not fully support the assigned evidence type.

## Checklist

- [x] All changes are well summarized
- [x] Check all tests pass
- [x] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If breaking change, increment X.
- [x] Ask someone to review this PR