### PR TITLE
XDP_TAF1-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5927,7 +5927,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 6,
     "category_max_score": 6,
-    "publication_date": "2019-06-01 00:00:00",
     "publication_dates": ["2019-06-01"]
   },
   {
@@ -5939,7 +5938,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 2,
     "category_max_score": 3,
-    "publication_date": null,
     "publication_dates": ["2017-12-19", "2022-06-01", "2022-04-08"]
   },
   {
@@ -5951,7 +5949,6 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 3,
     "category_max_score": 3,
-    "publication_date": null,
     "publication_dates": ["2017-12-19", "1995-09-01"]
   }],
   "experimental_evidence_details": [
@@ -5964,7 +5961,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": "2024-10-01 00:00:00",
     "publication_dates": ["2024-10-01"]
   },
   {
@@ -5976,7 +5972,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
-    "publication_date": null,
     "publication_dates": ["2007-03-01", "2018-02-22", "2019-06-01"]
   },
   {
@@ -5988,7 +5983,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 1,
     "category_max_score": 2,
-    "publication_date": "2022-07-21 00:00:00",
     "publication_dates": ["2022-07-21"]
   },
   {
@@ -6000,7 +5994,6 @@
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,
     "category_max_score": 4,
-    "publication_date": "2021-08-01 00:00:00",
     "publication_dates": ["2021-08-01"]
   }],
   "category_summary":

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5913,108 +5913,115 @@
   "Inheritance": "XR",
   "Curator": "Macayla Weiner, Laurel Hiatt, Elbay Aliyev",
   "Date": "8/14/2025",
-  "Manual_evidence_level": "Definitive",
   "Description": "X-linked dystonia-parkinsonism (XDP) is an adult-onset, X-linked movement disorder most often affecting males of Filipino/Panay ancestry and associated with a founder SVA retrotransposon insertion in intron 32 of TAF1. The XDP SVA contains a variable (CCCTCT)n hexameric repeat whose length correlates inversely with age at onset and shows tissue-specific somatic instability in brain. Genetic studies support segregation of the XDP haplotype/SVA with disease, while functional studies show SVA-associated TAF1 dysregulation, including reduced TAF1 expression, intron 32 retention/aberrant splicing, and epigenetic effects involving DNA methylation and H3K9me3.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
-  "category_summary": {
+  "Manual_evidence_level": null,
+  "genetic_evidence_details": [
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:30973967",
+    "Evidence detail": "PMID:30973967 enrolled 52 male patients with clinically and genetically confirmed XDP, typical X-linked family history, Panay maternal ancestry, and molecular confirmation of TAF1 haplotype variants; this supports affected-case ascertainment but is not a primary locus-discovery cohort.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_date": "2019-06-01 00:00:00",
+    "publication_dates": ["2019-06-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 2.0,
+    "Citation": "pmid:29229810; pmid:38835911; pmid:35395816",
+    "Evidence detail": "PMID:29229810 identified polymorphic (CCCTCT)n repeat length within the XDP-specific TAF1 SVA in 140 patients, with 35-52 repeats and a significant inverse correlation with age at onset. PMID:35395816 confirmed repeat-length associations with age at onset/death and showed repeat-length-dependent somatic expansion in blood and brain; PMID:38835911 summarizes repeat length and modifier effects on variable expressivity.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_date": null,
+    "publication_dates": ["2017-12-19", "2022-06-01", "2022-04-08"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:29229810; pmid:7668293",
+    "Evidence detail": "PMID:7668293 found the same DXS7117/DXS7119 haplotype in 42/47 unrelated XDP patients and used linkage disequilibrium to localize DYT3 to Xq13.1. PMID:29229810 reports that affected individuals share the XDP founder haplotype containing the TAF1 SVA and that these variants were not found in ethnically matched or other controls.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_date": null,
+    "publication_dates": ["2017-12-19", "1995-09-01"]
+  }],
+  "experimental_evidence_details": [
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:38834915",
+    "Evidence detail": "PMID:38834915 showed that the KRAB zinc-finger protein ZNF91 recognizes SVAs in neural progenitor cells and helps establish H3K9me3/DNA methylation over the polymorphic XDP SVA; this supports a transposon-regulatory protein interaction rather than a direct TAF1 protein-protein interaction.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": "2024-10-01 00:00:00",
+    "publication_dates": ["2024-10-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 2.0,
+    "Citation": "pmid:17273961; pmid:29474918; pmid:30973967 ",
+    "Evidence detail": "PMID:17273961 identified the XDP-specific SVA insertion in TAF1 and reduced TAF1/DRD2 expression plus altered SVA methylation in XDP caudate. PMID:29474918 showed decreased cTAF1, SVA-proximal intron retention/aberrant splicing, and normalization after CRISPR/Cas9 SVA excision. PMID:30973967 provides clinical context only and does not add molecular regulatory evidence.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_date": null,
+    "publication_dates": ["2007-03-01", "2018-02-22", "2019-06-01"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:35868859",
+    "Evidence detail": "PMID:35868859 characterized eight iPSC lines from three heterozygous female XDP carriers with X-chromosome-inactivation clones expressing either the wild-type or XDP haplotype, providing non-patient carrier cell resources for modeling TAF1/SVA effects.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_date": "2022-07-21 00:00:00",
+    "publication_dates": ["2022-07-21"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 1.0,
+    "Citation": "pmid:34250228",
+    "Evidence detail": "",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_date": "2021-08-01 00:00:00",
+    "publication_dates": ["2021-08-01"]
+  }],
+  "category_summary":
+  {
+    "Singular Evidence": 6.0,
     "Collective Evidence": 3,
+    "Statistics": 0,
     "Function": 2,
     "Functional Alteration": 0.5,
     "Models": 1.0,
-    "Singular Evidence": 6.0,
-    "Statistics": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 4.0,
     "Genetic Evidence": 9.5
   },
   "total_score": 13.5,
-  "classification": "Definitive",
-  "publication_count": 7,
-  "publication_interval_years": 5.34,
-  "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:30973967",
-      "Evidence detail": "PMID:30973967 enrolled 52 male patients with clinically and genetically confirmed XDP, typical X-linked family history, Panay maternal ancestry, and molecular confirmation of TAF1 haplotype variants; this supports affected-case ascertainment but is not a primary locus-discovery cohort.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_date": "2019-06-01 00:00:00"
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 2.0,
-      "Citation": "pmid:29229810; pmid:38835911; pmid:35395816",
-      "Evidence detail": "PMID:29229810 identified polymorphic (CCCTCT)n repeat length within the XDP-specific TAF1 SVA in 140 patients, with 35-52 repeats and a significant inverse correlation with age at onset. PMID:35395816 confirmed repeat-length associations with age at onset/death and showed repeat-length-dependent somatic expansion in blood and brain; PMID:38835911 summarizes repeat length and modifier effects on variable expressivity.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_date": null
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:29229810; pmid:7668293",
-      "Evidence detail": "PMID:7668293 found the same DXS7117/DXS7119 haplotype in 42/47 unrelated XDP patients and used linkage disequilibrium to localize DYT3 to Xq13.1. PMID:29229810 reports that affected individuals share the XDP founder haplotype containing the TAF1 SVA and that these variants were not found in ethnically matched or other controls.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_date": null
-    }
-  ],
-  "experimental_evidence_details": [
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:38834915",
-      "Evidence detail": "PMID:38834915 showed that the KRAB zinc-finger protein ZNF91 recognizes SVAs in neural progenitor cells and helps establish H3K9me3/DNA methylation over the polymorphic XDP SVA; this supports a transposon-regulatory protein interaction rather than a direct TAF1 protein-protein interaction.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2024-10-01 00:00:00"
-    },
-    {
-      "Evidence type": "Regulatory Impact",
-      "Score": 2.0,
-      "Citation": "pmid:17273961; pmid:29474918; pmid:30973967 ",
-      "Evidence detail": "PMID:17273961 identified the XDP-specific SVA insertion in TAF1 and reduced TAF1/DRD2 expression plus altered SVA methylation in XDP caudate. PMID:29474918 showed decreased cTAF1, SVA-proximal intron retention/aberrant splicing, and normalization after CRISPR/Cas9 SVA excision. PMID:30973967 provides clinical context only and does not add molecular regulatory evidence.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": null
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:35868859",
-      "Evidence detail": "PMID:35868859 characterized eight iPSC lines from three heterozygous female XDP carriers with X-chromosome-inactivation clones expressing either the wild-type or XDP haplotype, providing non-patient carrier cell resources for modeling TAF1/SVA effects.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_date": "2022-07-21 00:00:00"
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 1.0,
-      "Citation": "pmid:34250228",
-      "Evidence detail": "",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_date": "2021-08-01 00:00:00"
-    }
-  ]
+  "publication_count": 10,
+  "publication_interval_years": 29.08,
+  "classification": "Definitive"
 },
 {
   "Disease_ID": "SCA17",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5912,7 +5912,7 @@
   "Locus_ID": "XDP_TAF1",
   "Inheritance": "XR",
   "Curator": "Macayla Weiner, Laurel Hiatt, Elbay Aliyev",
-  "Date": "8/14/2025",
+  "Date": "08/14/2025",
   "Description": "X-linked dystonia-parkinsonism (XDP) is an adult-onset, X-linked movement disorder most often affecting males of Filipino/Panay ancestry and associated with a founder SVA retrotransposon insertion in intron 32 of TAF1. The XDP SVA contains a variable (CCCTCT)n hexameric repeat whose length correlates inversely with age at onset and shows tissue-specific somatic instability in brain. Genetic studies support segregation of the XDP haplotype/SVA with disease, while functional studies show SVA-associated TAF1 dysregulation, including reduced TAF1 expression, intron 32 retention/aberrant splicing, and epigenetic effects involving DNA methylation and H3K9me3.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5911,110 +5911,110 @@
   "Gene": "TAF1",
   "Locus_ID": "XDP_TAF1",
   "Inheritance": "XR",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
-  "Date": "08/14/2025",
-  "Description": null,
+  "Curator": "Macayla Weiner, Laurel Hiatt, Elbay Aliyev",
+  "Date": "8/14/2025",
+  "Manual_evidence_level": "Definitive",
+  "Description": "X-linked dystonia-parkinsonism (XDP) is an adult-onset, X-linked movement disorder most often affecting males of Filipino/Panay ancestry and associated with a founder SVA retrotransposon insertion in intron 32 of TAF1. The XDP SVA contains a variable (CCCTCT)n hexameric repeat whose length correlates inversely with age at onset and shows tissue-specific somatic instability in brain. Genetic studies support segregation of the XDP haplotype/SVA with disease, while functional studies show SVA-associated TAF1 dysregulation, including reduced TAF1 expression, intron 32 retention/aberrant splicing, and epigenetic effects involving DNA methylation and H3K9me3.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
-  "Manual_evidence_level": "Definitive",
-  "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:30973967",
-    "Evidence detail": null,
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2019-06-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 2.0,
-    "Citation": "pmid:29229810; pmid:38835911; pmid:35395816",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2017-12-19", "2022-06-01", "2022-04-08"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:29229810; pmid:7668293",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2017-12-19", "1995-09-01"]
-  }],
-  "experimental_evidence_details": [
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:38834915",
-    "Evidence detail": " protein",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-10-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 2.0,
-    "Citation": "pmid:17273961; pmid:29474918; pmid:30973967 ",
-    "Evidence detail": "TAF1 expression, methylation decrease, transcriptome alterations",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2007-03-01", "2018-02-22", "2019-06-01"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:35868859",
-    "Evidence detail": "carrier iPSCs",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2022-07-21"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 1.0,
-    "Citation": "pmid:34250228",
-    "Evidence detail": "brain cell types",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2021-08-01"]
-  }],
-  "category_summary":
-  {
-    "Singular Evidence": 6.0,
+  "category_summary": {
     "Collective Evidence": 3,
-    "Statistics": 0,
     "Function": 2,
     "Functional Alteration": 0.5,
     "Models": 1.0,
+    "Singular Evidence": 6.0,
+    "Statistics": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 4.0,
     "Genetic Evidence": 9.5
   },
   "total_score": 13.5,
-  "publication_count": 10,
-  "publication_interval_years": 29.08,
-  "classification": "Definitive"
+  "classification": "Definitive",
+  "publication_count": 7,
+  "publication_interval_years": 5.34,
+  "genetic_evidence_details": [
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:30973967",
+      "Evidence detail": "PMID:30973967 enrolled 52 male patients with clinically and genetically confirmed XDP, typical X-linked family history, Panay maternal ancestry, and molecular confirmation of TAF1 haplotype variants; this supports affected-case ascertainment but is not a primary locus-discovery cohort.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_date": "2019-06-01 00:00:00"
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 2.0,
+      "Citation": "pmid:29229810; pmid:38835911; pmid:35395816",
+      "Evidence detail": "PMID:29229810 identified polymorphic (CCCTCT)n repeat length within the XDP-specific TAF1 SVA in 140 patients, with 35-52 repeats and a significant inverse correlation with age at onset. PMID:35395816 confirmed repeat-length associations with age at onset/death and showed repeat-length-dependent somatic expansion in blood and brain; PMID:38835911 summarizes repeat length and modifier effects on variable expressivity.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_date": null
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:29229810; pmid:7668293",
+      "Evidence detail": "PMID:7668293 found the same DXS7117/DXS7119 haplotype in 42/47 unrelated XDP patients and used linkage disequilibrium to localize DYT3 to Xq13.1. PMID:29229810 reports that affected individuals share the XDP founder haplotype containing the TAF1 SVA and that these variants were not found in ethnically matched or other controls.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_date": null
+    }
+  ],
+  "experimental_evidence_details": [
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:38834915",
+      "Evidence detail": "PMID:38834915 showed that the KRAB zinc-finger protein ZNF91 recognizes SVAs in neural progenitor cells and helps establish H3K9me3/DNA methylation over the polymorphic XDP SVA; this supports a transposon-regulatory protein interaction rather than a direct TAF1 protein-protein interaction.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2024-10-01 00:00:00"
+    },
+    {
+      "Evidence type": "Regulatory Impact",
+      "Score": 2.0,
+      "Citation": "pmid:17273961; pmid:29474918; pmid:30973967 ",
+      "Evidence detail": "PMID:17273961 identified the XDP-specific SVA insertion in TAF1 and reduced TAF1/DRD2 expression plus altered SVA methylation in XDP caudate. PMID:29474918 showed decreased cTAF1, SVA-proximal intron retention/aberrant splicing, and normalization after CRISPR/Cas9 SVA excision. PMID:30973967 provides clinical context only and does not add molecular regulatory evidence.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": null
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:35868859",
+      "Evidence detail": "PMID:35868859 characterized eight iPSC lines from three heterozygous female XDP carriers with X-chromosome-inactivation clones expressing either the wild-type or XDP haplotype, providing non-patient carrier cell resources for modeling TAF1/SVA effects.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_date": "2022-07-21 00:00:00"
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 1.0,
+      "Citation": "pmid:34250228",
+      "Evidence detail": "",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_date": "2021-08-01 00:00:00"
+    }
+  ]
 },
 {
   "Disease_ID": "SCA17",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5975,7 +5975,7 @@
     "publication_dates": ["2007-03-01", "2018-02-22", "2019-06-01"]
   },
   {
-    "Evidence type": "Non-patient cells",
+    "Evidence type": "Patient cells",
     "Score": 0.5,
     "Citation": "pmid:35868859",
     "Evidence detail": "PMID:35868859 characterized eight iPSC lines from three heterozygous female XDP carriers with X-chromosome-inactivation clones expressing either the wild-type or XDP haplotype, providing non-patient carrier cell resources for modeling TAF1/SVA effects.",
@@ -5986,10 +5986,10 @@
     "publication_dates": ["2022-07-21"]
   },
   {
-    "Evidence type": "Non-human model organism",
+    "Evidence type": "Patient cells",
     "Score": 1.0,
     "Citation": "pmid:34250228",
-    "Evidence detail": "",
+    "Evidence detail": "Repeat sizing and somatic instability in human postmortem brain tissues from two XDP patients showed higher median repeat numbers and higher degrees of repeat instability in the basal ganglia and cerebellum compared with blood.",
     "evidence_category": "Models",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,


### PR DESCRIPTION
Description

Updated the criTRia evidence details and root-level description for TAF1 / XDP based on the reviewed literature and SOP-guided curation.

Fixes: # Link to any relevant issues and/or discussions

Major Changes
None.
Minor Changes
Added a concise root-level description summarizing the TAF1/XDP locus-disease relationship.
Updated vague or missing evidence detail fields for existing genetic and experimental evidence rows.
Clarified support for the XDP-specific TAF1 intron 32 SVA retrotransposon insertion and the variable (CCCTCT)n hexameric repeat.
Added clearer evidence summaries for:
proband/cohort evidence
repeat length correlation with age at onset
segregation/linkage evidence
TAF1 regulatory impact and aberrant transcription
carrier iPSC/non-patient-cell evidence
SVA-associated chromatin regulation
Flagged curator-review concerns where the cited evidence type may not fully match the source:
PMID:30973967 appears to provide clinical/caregiver cohort context rather than primary proband genetic discovery evidence.
PMID:34250228 reports human postmortem brain repeat-instability data, not a non-human model organism.
Checklist
 All changes are well summarized
 Check all tests pass
 Check that the website preview looks good
 Update the STRchive version in CITATION.cff, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
 Ask someone to review this PR