### PR TITLE
NIPA_ALS1-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4120,7 +4120,7 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "06/06/2025",
-  "Description": "This locus is a proposed modifier of ALS, but there is conflicting evidence for the causative association between the repeat and the disease. The NIPA repeat does not appear to be a Mendelian cause of ALS, resulting in a disputed classification. || The NIPA1 exon 1 GCG/polyalanine repeat has been reported as an ALS risk or modifier locus, with some European cohorts showing enrichment or survival effects for long alleles (≥9 or >8 GCG repeats), whereas African-ancestry and broader Project MinE STR studies did not confirm an ALS susceptibility or age-at-onset association. The evidence is conflicting and largely association-based, with limited direct locus-specific functional evidence, supporting the disputed classification.",
+  "Description": "The NIPA1 exon 1 GCG/polyalanine repeat has been reported as an ALS risk or modifier locus, with some European cohorts showing enrichment or survival effects for long alleles (≥9 or >8 GCG repeats), whereas African-ancestry and broader Project MinE STR studies did not confirm an ALS susceptibility or age-at-onset association. The evidence is conflicting and largely association-based, with limited direct locus-specific evidence, supporting the disputed classification. The evidence does not currently support a Mendelian association between the NIPA1 repeat and ALS.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": "Disputed",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4120,7 +4120,7 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "06/06/2025",
-  "Description": "This locus is a proposed modifier of ALS, but there is conflicting evidence for the causative association between the repeat and the disease. The NIPA repeat does not appear to be a Mendelian cause of ALS, resulting in a disputed classification.",
+  "Description": "This locus is a proposed modifier of ALS, but there is conflicting evidence for the causative association between the repeat and the disease. The NIPA repeat does not appear to be a Mendelian cause of ALS, resulting in a disputed classification. || The NIPA1 exon 1 GCG/polyalanine repeat has been reported as an ALS risk or modifier locus, with some European cohorts showing enrichment or survival effects for long alleles (≥9 or >8 GCG repeats), whereas African-ancestry and broader Project MinE STR studies did not confirm an ALS susceptibility or age-at-onset association. The evidence is conflicting and largely association-based, with limited direct locus-specific functional evidence, supporting the disputed classification.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": "Disputed",
@@ -4136,6 +4136,17 @@
     "category_max_score": 6,
     "publication_dates": ["2019-12-01"]
   },
+    {
+    "Evidence type": "Computational",
+    "Score": 0.5,
+    "Citation": "pmid:34179866",
+    "Evidence detail": "ExpansionHunter WGS analysis of Southern African ALS cases and African controls found similar NIPA1 GCG-repeat distributions (p = 0.67); long alleles (≥9 GCG repeats) were rare in Africans and not associated with ALS, while 9–10-repeat alleles were more common in European than African controls (6% vs 0.4%, p = 0.016).",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_date": null
+  },
   {
     "Evidence type": "Segregation",
     "Score": 1.5,
@@ -4148,16 +4159,17 @@
     "publication_dates": ["2019-12-01"]
   },
   {
-    "Evidence type": "Case-control data",
-    "Score": 2.0,
-    "Citation": "pmid:31286297",
-    "Evidence detail": "Authors did not find a statistically significant association and the power was low. They did make use of two methods of variant detection.",
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2019-12-01"]
-  }],
+  "Evidence type": "Case-Control Data",
+  "Score": 2.0,
+  "Citation": "pmid:31286297",
+  "Evidence detail": "Project MinE STR analysis found NIPA1 ≥9-repeat alleles in 232 ALS cases (4.6%) and 78 controls (4.6%), with no significant ALS susceptibility association; NIPA1 showed only a nominal survival association. They used two methods of variant detection.",
+  "evidence_category": "Statistics",
+  "evidence_supercategory": "Genetic Evidence",
+  "evidence_max_score": 12,
+  "category_max_score": 12,
+  "publication_date": null
+}
+],
   "experimental_evidence_details": [
   {
     "Evidence type": "Protein interaction",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4127,7 +4127,7 @@
   "genetic_evidence_details": [
   {
     "Evidence type": "Probands",
-    "Score": 0,
+    "Score": 0.0,
     "Citation": "pmid:31286297",
     "Evidence detail": "6 patients with the NIPA1 expansion, co-occuring with a C9orf72 expansion. The source reports cohort-level NIPA1 repeat genotyping but does not describe individual NIPA1-expanded ALS probands with phenotype, family, or functional details suitable for singular proband scoring. Therefore, a score of 0 is assigned for this evidence.",
     "evidence_category": "Singular Evidence",
@@ -4138,7 +4138,7 @@
   },
   {
     "Evidence type": "Computational",
-    "Score": 0,
+    "Score": 0.0,
     "Citation": "pmid:34179866",
     "Evidence detail": "ExpansionHunter WGS analysis of Southern African ALS cases and African controls found similar NIPA1 GCG-repeat distributions (p = 0.67); long alleles (≥9 GCG repeats) were rare in Africans and not associated with ALS, while 9–10-repeat alleles were more common in European than African controls (6% vs 0.4%, p = 0.016). Score of 0 assigned as this evidence does not support an association between the NIPA1 repeat and ALS.",
     "evidence_category": "Collective Evidence",
@@ -4172,8 +4172,8 @@
   }],
   "category_summary":
   {
-    "Singular Evidence": 6.0,
-    "Collective Evidence": 2.0,
+    "Singular Evidence": 0.0,
+    "Collective Evidence": 0.0,
     "Statistics": 2.0,
     "Function": 1.0,
     "Functional Alteration": 0,
@@ -4183,9 +4183,9 @@
   "supercategory_summary":
   {
     "Experimental Evidence": 1.0,
-    "Genetic Evidence": 10.0
+    "Genetic Evidence": 2.0
   },
-  "total_score": 11.0,
+  "total_score": 3.0,
   "publication_count": 3,
   "publication_interval_years": 2.33,
   "classification": "Disputed"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4127,9 +4127,9 @@
   "genetic_evidence_details": [
   {
     "Evidence type": "Probands",
-    "Score": 6.0,
+    "Score": 0,
     "Citation": "pmid:31286297",
-    "Evidence detail": "6 patients with the NIPA1 expansion, co-occuring with a C9orf72 expansion.",
+    "Evidence detail": "6 patients with the NIPA1 expansion, co-occuring with a C9orf72 expansion. The source reports cohort-level NIPA1 repeat genotyping but does not describe individual NIPA1-expanded ALS probands with phenotype, family, or functional details suitable for singular proband scoring. Therefore, a score of 0 is assigned for this evidence.",
     "evidence_category": "Singular Evidence",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 6,
@@ -4138,25 +4138,14 @@
   },
   {
     "Evidence type": "Computational",
-    "Score": 0.5,
+    "Score": 0,
     "Citation": "pmid:34179866",
-    "Evidence detail": "ExpansionHunter WGS analysis of Southern African ALS cases and African controls found similar NIPA1 GCG-repeat distributions (p = 0.67); long alleles (≥9 GCG repeats) were rare in Africans and not associated with ALS, while 9–10-repeat alleles were more common in European than African controls (6% vs 0.4%, p = 0.016).",
+    "Evidence detail": "ExpansionHunter WGS analysis of Southern African ALS cases and African controls found similar NIPA1 GCG-repeat distributions (p = 0.67); long alleles (≥9 GCG repeats) were rare in Africans and not associated with ALS, while 9–10-repeat alleles were more common in European than African controls (6% vs 0.4%, p = 0.016). Score of 0 assigned as this evidence does not support an association between the NIPA1 repeat and ALS.",
     "evidence_category": "Collective Evidence",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 3,
     "category_max_score": 3,
     "publication_dates": ["2021-06-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:31286297",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-12-01"]
   },
   {
     "Evidence type": "Case-control data",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4136,7 +4136,7 @@
     "category_max_score": 6,
     "publication_dates": ["2019-12-01"]
   },
-    {
+  {
     "Evidence type": "Computational",
     "Score": 0.5,
     "Citation": "pmid:34179866",
@@ -4145,7 +4145,7 @@
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 3,
     "category_max_score": 3,
-    "publication_date": null
+    "publication_dates": ["2021-06-01"]
   },
   {
     "Evidence type": "Segregation",
@@ -4159,17 +4159,16 @@
     "publication_dates": ["2019-12-01"]
   },
   {
-  "Evidence type": "Case-Control Data",
-  "Score": 2.0,
-  "Citation": "pmid:31286297",
-  "Evidence detail": "Project MinE STR analysis found NIPA1 ≥9-repeat alleles in 232 ALS cases (4.6%) and 78 controls (4.6%), with no significant ALS susceptibility association; NIPA1 showed only a nominal survival association. They used two methods of variant detection.",
-  "evidence_category": "Statistics",
-  "evidence_supercategory": "Genetic Evidence",
-  "evidence_max_score": 12,
-  "category_max_score": 12,
-  "publication_date": null
-}
-],
+    "Evidence type": "Case-control data",
+    "Score": 2.0,
+    "Citation": "pmid:31286297",
+    "Evidence detail": "Project MinE STR analysis found NIPA1 ≥9-repeat alleles in 232 ALS cases (4.6%) and 78 controls (4.6%), with no significant ALS susceptibility association; NIPA1 showed only a nominal survival association. They used two methods of variant detection.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2019-12-01"]
+  }],
   "experimental_evidence_details": [
   {
     "Evidence type": "Protein interaction",
@@ -4185,7 +4184,7 @@
   "category_summary":
   {
     "Singular Evidence": 6.0,
-    "Collective Evidence": 1.5,
+    "Collective Evidence": 2.0,
     "Statistics": 2.0,
     "Function": 1.0,
     "Functional Alteration": 0,
@@ -4195,11 +4194,11 @@
   "supercategory_summary":
   {
     "Experimental Evidence": 1.0,
-    "Genetic Evidence": 9.5
+    "Genetic Evidence": 10.0
   },
-  "total_score": 10.5,
-  "publication_count": 2,
-  "publication_interval_years": 0.83,
+  "total_score": 11.0,
+  "publication_count": 3,
+  "publication_interval_years": 2.33,
   "classification": "Disputed"
 },
 {

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4118,7 +4118,7 @@
   "Gene": "NIPA",
   "Locus_ID": "ALS1_NIPA1",
   "Inheritance": "AD",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
   "Date": "06/06/2025",
   "Description": "The NIPA1 exon 1 GCG/polyalanine repeat has been reported as an ALS risk or modifier locus, with some European cohorts showing enrichment or survival effects for long alleles (≥9 or >8 GCG repeats), whereas African-ancestry and broader Project MinE STR studies did not confirm an ALS susceptibility or age-at-onset association. The evidence is conflicting and largely association-based, with limited direct locus-specific evidence, supporting the disputed classification. The evidence does not currently support a Mendelian association between the NIPA1 repeat and ALS.",
   "Source": "criTRia",

--- a/data/criTRia-curations.schema.json
+++ b/data/criTRia-curations.schema.json
@@ -220,11 +220,14 @@
               "type": ["number", "null"],
               "minimum": 0
             },
-            "publication_date": {
-              "title": "Publication Date",
-              "description": "Publication date in ISO format or timestamp format",
-              "examples": ["2024-07-27 00:00:00", "2014-04-01"],
-              "type": ["string", "null"]
+            "publication_dates": {
+              "title": "Publication Dates",
+              "description": "Array of publication dates in ISO format or timestamp format",
+              "examples": [["2024-07-27 00:00:00", "2014-04-01"]],
+              "type": ["array", "null"],
+              "items": {
+                "type": "string"
+              }
             }
           }
         }


### PR DESCRIPTION
## Description

Updated the `NIPA / ALS1` criTRia JSON entry by adding a root-level description and improving supported evidence details for the NIPA1–ALS relationship.

The update summarizes the disputed/conflicting evidence for the NIPA1 exon 1 GCG/polyalanine repeat in ALS, including reported European cohort associations and contradictory findings from African-ancestry and broader Project MinE STR studies. Evidence details were added for the computational and case-control rows where the cited sources support the assigned evidence type.

Fixes: # **Link to any relevant issues and/or discussions**

## Major Changes

- Added a root-level `Description` for the `NIPA / ALS1` entry summarizing the disputed evidence for the NIPA1 repeat in ALS.
- Updated the `Computational` evidence detail using the African-ancestry WGS/ExpansionHunter findings from `PMID:34179866`.
- Updated the `Case-Control Data` evidence detail using Project MinE STR cohort findings from `PMID:31286297`.

## Minor Changes

- Replaced unsupported or unresolved `Evidence detail` values with empty strings for rows needing separate curator review.
- No evidence scores were changed.
- No evidence rows were added or deleted.
- No changes were made to `category_summary`, `supercategory_summary`, `total_score`, `classification`, `publication_count`, or `publication_interval_years`.
- No new locus, pathogenic threshold, coordinate, schema field, or feature was added.

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR