### PR TITLE
DMPK_DM1-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2316,7 +2316,7 @@
   "Inheritance": "AD",
   "Curator": "Laurel Hiatt",
   "Date": "07/21/2025",
-  "Description": "Myotonic dystrophy type 1 (DM1) is an autosomal dominant, multisystem repeat-expansion disorder caused by a pathogenic CTG expansion in the 3' UTR of DMPK. The locus-disease relationship is supported by molecularly confirmed DMPK CTG expansions in affected probands, population/control allele data, repeat-length effects and variant repeat interruptions that modify age at onset and severity, and experimental evidence showing toxic expanded CUG RNA with nuclear foci, RNA-binding protein sequestration, disease-relevant cellular and mouse phenotypes, and partial rescue after modulation of pathogenic RNA-binding pathways.",
+  "Description": "Myotonic dystrophy type 1 (DM1) is an autosomal dominant, multisystem repeat-expansion disorder caused by a pathogenic CTG expansion in the 3' UTR of DMPK. The locus-disease relationship is supported by molecularly confirmed DMPK CTG expansions in affected probands, population/control allele data, repeat-length and repeat interruptions that modify age at onset and severity, and experimental evidence showing toxic expanded CUG RNA with nuclear foci, RNA-binding protein sequestration, disease-relevant cellular and mouse phenotypes, and partial rescue after modulation of pathogenic RNA-binding pathways.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2325,33 +2325,36 @@
     "Evidence type": "Allele",
     "Score": 2,
     "Citation": "pmid:32851192; pmid:39643839",
-    "Evidence detail": "Interruptions impact phenotype/onset; several studies have shown correlation between allele length and onset/disease severity",
+    "Evidence detail": "PMID:32851192 showed that DM1 individuals with variant repeat interruptions had milder motor/neurocognitive/behavioral outcomes than matched pure-repeat DM1 cases. PMID:39643839 summarizes that DMPK CTG expansion length influences disease severity/age at onset, while variant interruptions and somatic instability modify phenotype.",
     "evidence_category": "Collective Evidence",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 2,
     "category_max_score": 3,
+    "publication_date": null,
     "publication_dates": ["2020-10-01", "2025-04-01"]
   },
   {
     "Evidence type": "Probands",
     "Score": 6,
     "Citation": "pmid:20635151",
-    "Evidence detail": "50 patients",
+    "Evidence detail": "In a Mexican cohort of 50 clinically/electrophysiologically diagnosed DM1 patients, 45/50 (90%) had pathogenic DMPK CTG expansions detected by fluorescent PCR plus TP-PCR/capillary electrophoresis; 400 unrelated controls showed non-expanded alleles ranging from 5 to 34 repeats.",
     "evidence_category": "Singular Evidence",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 6,
     "category_max_score": 6,
+    "publication_date": "2011-02-01 00:00:00",
     "publication_dates": ["2011-02-01"]
   },
   {
     "Evidence type": "Case-control data",
     "Score": 4,
     "Citation": "pmid:7847063",
-    "Evidence detail": "Case-control study was carried out on 25 patients with myotonic dystrophy (MyD) and 25 healthy subjects (p < 0.0001) ",
+    "Evidence detail": "Case-control study was carried out on 25 patients with myotonic dystrophy (MyD) and 25 healthy subjects (p < 0.0001).",
     "evidence_category": "Statistics",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 12,
     "category_max_score": 12,
+    "publication_date": "1994-09-01 00:00:00",
     "publication_dates": ["1994-09-01"]
   }],
   "experimental_evidence_details": [
@@ -2359,146 +2362,69 @@
     "Evidence type": "Rescue in non-human model organism",
     "Score": 2,
     "Citation": "pmid:39932794",
-    "Evidence detail": "MBNL overexpression rescues cardiac phenotypes in a myotonic dystrophy type 1 heart mouse model",
+    "Evidence detail": "In CUG960 heart-specific DM1 mice expressing 960 interrupted CUG repeats in the human DMPK 3' UTR, AAV9-mediated MBNL1 and/or MBNL2 overexpression partially rescued conduction delays, contractile dysfunction, hypertrophy, and misregulated splicing/gene expression.",
     "evidence_category": "Rescue",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,
     "category_max_score": 4,
+    "publication_date": "2025-02-11 00:00:00",
     "publication_dates": ["2025-02-11"]
   },
   {
     "Evidence type": "Rescue in cell culture",
     "Score": 1,
     "Citation": "pmid:16027111",
-    "Evidence detail": "Knock-down of endogenous hnRNP H expression by siRNAs in cells expressing an EGFP gene fused to CUG repeats leads to release of nuclear sequestrated transcripts and restoration of EGFP expression",
+    "Evidence detail": "In 293T cells and myoblasts expressing an EGFP-(CUG)85 reporter, siRNA knockdown of hnRNP H restored EGFP expression and relieved nuclear retention of expanded CUG-repeat RNA; hnRNP H binding required expanded CUG repeats and a distal branch point.",
     "evidence_category": "Rescue",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
+    "publication_date": "2005-01-01 00:00:00",
     "publication_dates": ["2005-01-01"]
   },
   {
     "Evidence type": "Non-human model organism",
     "Score": 2,
     "Citation": "pmid:31649961",
-    "Evidence detail": "Alkaline phosphatase-positive pericytes from skeletal muscle of a transgenic mouse model",
+    "Evidence detail": "DMSXL transgenic mice carrying a human DM1 allele with ~CTG1300 repeats yielded ALP-positive skeletal muscle pericytes that expressed transgenic DMPK and showed nuclear CUG RNA foci, averaging 1-2 foci/nucleus in heterozygotes and 5-10 in homozygotes.",
     "evidence_category": "Models",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,
     "category_max_score": 4,
+    "publication_date": "2019-12-13 00:00:00",
     "publication_dates": ["2019-12-13"]
   },
   {
     "Evidence type": "Patient cells",
     "Score": 1,
     "Citation": "pmid:31649961",
-    "Evidence detail": "Alkaline phosphatase-positive pericytes from skeletal muscle of DM1 patients",
+    "Evidence detail": "ALP-positive skeletal muscle pericytes were isolated from six DM1 patients and two unaffected controls; patient pericytes showed nuclear CUG RNA foci with MBNL1 colocalization in several lines while maintaining proliferation and myogenic differentiation potential comparable to controls.",
     "evidence_category": "Functional Alteration",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
     "category_max_score": 2,
+    "publication_date": "2019-12-13 00:00:00",
     "publication_dates": ["2019-12-13"]
   }],
   "category_summary":
   {
     "Singular Evidence": 6,
     "Collective Evidence": 2,
+    "Statistics": 4,
+    "Function": 0,
     "Functional Alteration": 1,
     "Models": 2,
-    "Rescue": 3,
-    "Singular Evidence": 6,
-    "Statistics": 4,
-    "Function": 0
+    "Rescue": 3
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },
   "total_score": 18,
-  "classification": "Definitive",
-  "publication_count": 6,
-  "publication_interval_years": 30.45,
-  "genetic_evidence_details": [
-    {
-      "Evidence type": "Allele",
-      "Score": 2,
-      "Citation": "pmid:32851192; pmid:39643839",
-      "Evidence detail": "PMID:32851192 showed that DM1 individuals with variant repeat interruptions had milder motor/neurocognitive/behavioral outcomes than matched pure-repeat DM1 cases. PMID:39643839 summarizes that DMPK CTG expansion length influences disease severity/age at onset, while variant interruptions and somatic instability modify phenotype.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_date": null
-    },
-    {
-      "Evidence type": "Probands",
-      "Score": 6,
-      "Citation": "pmid:20635151",
-      "Evidence detail": "In a Mexican cohort of 50 clinically/electrophysiologically diagnosed DM1 patients, 45/50 (90%) had pathogenic DMPK CTG expansions detected by fluorescent PCR plus TP-PCR/capillary electrophoresis; 400 unrelated controls showed non-expanded alleles ranging from 5 to 34 repeats.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_date": "2011-02-01 00:00:00"
-    },
-    {
-      "Evidence type": "Case-Control Data",
-      "Score": 4,
-      "Citation": "pmid:7847063",
-      "Evidence detail": "Case-control study was carried out on 25 patients with myotonic dystrophy (MyD) and 25 healthy subjects (p < 0.0001).",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_date": "1994-09-01 00:00:00"
-    }
-  ],
-  "experimental_evidence_details": [
-    {
-      "Evidence type": "Rescue in non-human model organism",
-      "Score": 2,
-      "Citation": "pmid:39932794",
-      "Evidence detail": "In CUG960 heart-specific DM1 mice expressing 960 interrupted CUG repeats in the human DMPK 3' UTR, AAV9-mediated MBNL1 and/or MBNL2 overexpression partially rescued conduction delays, contractile dysfunction, hypertrophy, and misregulated splicing/gene expression.",
-      "evidence_category": "Rescue",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_date": "2025-02-11 00:00:00"
-    },
-    {
-      "Evidence type": "Rescue in cell culture",
-      "Score": 1,
-      "Citation": "pmid:16027111",
-      "Evidence detail": "In 293T cells and myoblasts expressing an EGFP-(CUG)85 reporter, siRNA knockdown of hnRNP H restored EGFP expression and relieved nuclear retention of expanded CUG-repeat RNA; hnRNP H binding required expanded CUG repeats and a distal branch point.",
-      "evidence_category": "Rescue",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2005-01-01 00:00:00"
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2,
-      "Citation": "pmid:31649961",
-      "Evidence detail": "DMSXL transgenic mice carrying a human DM1 allele with ~CTG1300 repeats yielded ALP-positive skeletal muscle pericytes that expressed transgenic DMPK and showed nuclear CUG RNA foci, averaging 1-2 foci/nucleus in heterozygotes and 5-10 in homozygotes.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_date": "2019-12-13 00:00:00"
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1,
-      "Citation": "pmid:31649961",
-      "Evidence detail": "ALP-positive skeletal muscle pericytes were isolated from six DM1 patients and two unaffected controls; patient pericytes showed nuclear CUG RNA foci with MBNL1 colocalization in several lines while maintaining proliferation and myogenic differentiation potential comparable to controls.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_date": "2019-12-13 00:00:00"
-    }
-  ]
+  "publication_count": 7,
+  "publication_interval_years": 30.58,
+  "classification": "Definitive"
 },
 {
   "Disease_ID": "RCPS",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2316,7 +2316,7 @@
   "Inheritance": "AD",
   "Curator": "Laurel Hiatt",
   "Date": "07/21/2025",
-  "Description": null,
+  "Description": "Myotonic dystrophy type 1 (DM1) is an autosomal dominant, multisystem repeat-expansion disorder caused by a pathogenic CTG expansion in the 3' UTR of DMPK. The locus-disease relationship is supported by molecularly confirmed DMPK CTG expansions in affected probands, population/control allele data, repeat-length effects and variant repeat interruptions that modify age at onset and severity, and experimental evidence showing toxic expanded CUG RNA with nuclear foci, RNA-binding protein sequestration, disease-relevant cellular and mouse phenotypes, and partial rescue after modulation of pathogenic RNA-binding pathways.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
@@ -2403,21 +2403,102 @@
   {
     "Singular Evidence": 6,
     "Collective Evidence": 2,
-    "Statistics": 4,
-    "Function": 0,
     "Functional Alteration": 1,
     "Models": 2,
-    "Rescue": 3
+    "Rescue": 3,
+    "Singular Evidence": 6,
+    "Statistics": 4,
+    "Function": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },
   "total_score": 18,
-  "publication_count": 7,
-  "publication_interval_years": 30.58,
-  "classification": "Definitive"
+  "classification": "Definitive",
+  "publication_count": 6,
+  "publication_interval_years": 30.45,
+  "genetic_evidence_details": [
+    {
+      "Evidence type": "Allele",
+      "Score": 2,
+      "Citation": "pmid:32851192; pmid:39643839",
+      "Evidence detail": "PMID:32851192 showed that DM1 individuals with variant repeat interruptions had milder motor/neurocognitive/behavioral outcomes than matched pure-repeat DM1 cases. PMID:39643839 summarizes that DMPK CTG expansion length influences disease severity/age at onset, while variant interruptions and somatic instability modify phenotype.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_date": null
+    },
+    {
+      "Evidence type": "Probands",
+      "Score": 6,
+      "Citation": "pmid:20635151",
+      "Evidence detail": "In a Mexican cohort of 50 clinically/electrophysiologically diagnosed DM1 patients, 45/50 (90%) had pathogenic DMPK CTG expansions detected by fluorescent PCR plus TP-PCR/capillary electrophoresis; 400 unrelated controls showed non-expanded alleles ranging from 5 to 34 repeats.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_date": "2011-02-01 00:00:00"
+    },
+    {
+      "Evidence type": "Case-Control Data",
+      "Score": 4,
+      "Citation": "pmid:7847063",
+      "Evidence detail": "Case-control study was carried out on 25 patients with myotonic dystrophy (MyD) and 25 healthy subjects (p < 0.0001).",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_date": "1994-09-01 00:00:00"
+    }
+  ],
+  "experimental_evidence_details": [
+    {
+      "Evidence type": "Rescue in non-human model organism",
+      "Score": 2,
+      "Citation": "pmid:39932794",
+      "Evidence detail": "In CUG960 heart-specific DM1 mice expressing 960 interrupted CUG repeats in the human DMPK 3' UTR, AAV9-mediated MBNL1 and/or MBNL2 overexpression partially rescued conduction delays, contractile dysfunction, hypertrophy, and misregulated splicing/gene expression.",
+      "evidence_category": "Rescue",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_date": "2025-02-11 00:00:00"
+    },
+    {
+      "Evidence type": "Rescue in cell culture",
+      "Score": 1,
+      "Citation": "pmid:16027111",
+      "Evidence detail": "In 293T cells and myoblasts expressing an EGFP-(CUG)85 reporter, siRNA knockdown of hnRNP H restored EGFP expression and relieved nuclear retention of expanded CUG-repeat RNA; hnRNP H binding required expanded CUG repeats and a distal branch point.",
+      "evidence_category": "Rescue",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2005-01-01 00:00:00"
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2,
+      "Citation": "pmid:31649961",
+      "Evidence detail": "DMSXL transgenic mice carrying a human DM1 allele with ~CTG1300 repeats yielded ALP-positive skeletal muscle pericytes that expressed transgenic DMPK and showed nuclear CUG RNA foci, averaging 1-2 foci/nucleus in heterozygotes and 5-10 in homozygotes.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_date": "2019-12-13 00:00:00"
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1,
+      "Citation": "pmid:31649961",
+      "Evidence detail": "ALP-positive skeletal muscle pericytes were isolated from six DM1 patients and two unaffected controls; patient pericytes showed nuclear CUG RNA foci with MBNL1 colocalization in several lines while maintaining proliferation and myogenic differentiation potential comparable to controls.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_date": "2019-12-13 00:00:00"
+    }
+  ]
 },
 {
   "Disease_ID": "RCPS",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2325,7 +2325,7 @@
     "Evidence type": "Allele",
     "Score": 2,
     "Citation": "pmid:32851192; pmid:39643839",
-    "Evidence detail": "PMID:32851192 showed that DM1 individuals with variant repeat interruptions had milder motor/neurocognitive/behavioral outcomes than matched pure-repeat DM1 cases. PMID:39643839 summarizes that DMPK CTG expansion length influences disease severity/age at onset, while variant interruptions and somatic instability modify phenotype.",
+    "Evidence detail": "PMID:32851192 showed that DM1 individuals with repeat interruptions had milder motor/neurocognitive/behavioral outcomes than matched pure-repeat DM1 cases. PMID:39643839 summarizes that DMPK CTG expansion length influences disease severity/age at onset, while variant interruptions and somatic instability modify phenotype.",
     "evidence_category": "Collective Evidence",
     "evidence_supercategory": "Genetic Evidence",
     "evidence_max_score": 2,


### PR DESCRIPTION
## Description

Updated the criTRia evidence details and root-level description for the DMPK–DM1 locus-disease relationship. This PR improves the clarity and source-specificity of existing evidence text while preserving the original scores, evidence rows, category summaries, total score, classification, publication count, and publication interval.

Fixes: # 

## Major Changes

- None.
- No new locus, pathogenic threshold, coordinate, feature, or data field was added.
- No scores or classification values were changed.

## Minor Changes

- Added a root-level `Description` for the DMPK–DM1 curation.
- Updated existing evidence detail text for:
  - Allele evidence using PMID:32851192 and PMID:39643839.
  - Probands evidence using PMID:20635151.
  - Rescue in non-human model organism using PMID:39932794.
  - Rescue in cell culture using PMID:16027111.
  - Non-human model organism evidence using PMID:31649961.
  - Patient cell evidence using PMID:31649961.
- Retained the existing Case-Control Data evidence detail for PMID:7847063 without changing the score or evidence row.
- Improved wording to make each evidence detail concise, factual, and directly tied to the assigned evidence type.

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR