### PR TITLE
SAMD12 FAME1 critria update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5988,7 +5988,7 @@
     "Evidence detail": "PMID:35868859 characterized eight iPSC lines from three heterozygous female XDP carriers with X-chromosome-inactivation clones expressing either the wild-type or XDP haplotype, providing non-patient carrier cell resources for modeling TAF1/SVA effects.",
     "evidence_category": "Functional Alteration",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
+    "evidence_max_score": 1,
     "category_max_score": 2,
     "publication_dates": ["2022-07-21"]
   },
@@ -5997,10 +5997,10 @@
     "Score": 1.0,
     "Citation": "pmid:34250228",
     "Evidence detail": "Repeat sizing and somatic instability in human postmortem brain tissues from two XDP patients showed higher median repeat numbers and higher degrees of repeat instability in the basal ganglia and cerebellum compared with blood.",
-    "evidence_category": "Functional Alteration",
+    "evidence_category": "Models",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
+    "evidence_max_score": 4,
+    "category_max_score": 4,
     "publication_dates": ["2021-08-01"]
   }],
   "category_summary":
@@ -6009,8 +6009,8 @@
     "Collective Evidence": 3,
     "Statistics": 0,
     "Function": 2,
-    "Functional Alteration": 1.5,
-    "Models": 0,
+    "Functional Alteration": 0.5,
+    "Models": 1.0,
     "Rescue": 0
   },
   "supercategory_summary":

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5810,17 +5810,17 @@
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 0,
-    "Function": 2.0,
+    "Function": 1.5,
     "Functional Alteration": 0,
     "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 2.0,
+    "Experimental Evidence": 1.5,
     "Genetic Evidence": 10.0
   },
-  "total_score": 12.0,
+  "total_score": 11.5,
   "publication_count": 5,
   "publication_interval_years": 6.84,
   "classification": "Definitive"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5733,80 +5733,94 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/14/2025",
-  "Description": null,
+  "Description": "Intronic SAMD12 pentanucleotide repeat expansions involving pathogenic TTTCA insertion with accompanying TTTTA expansion cause autosomal dominant familial adult myoclonic epilepsy type 1 (FAME1/FCMTE1). Multiple studies report affected families across Asian populations, segregation with disease, absence of the TTTCA insertion from controls, computational and long-read detection of the expansion, length-dependent genotype-phenotype correlations, and neuronal UUUCA RNA foci supporting RNA-mediated toxicity.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:39569876",
-    "Evidence detail": null,
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2025-02-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 2.0,
-    "Citation": "pmid:39569876",
-    "Evidence detail": "(TTTCA)exp counts were inversely correlated with the age at onset for cortical tremor and epilepsy ",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2025-02-01"]
-  },
-  {
-    "Evidence type": "Computational",
-    "Score": 0.5,
-    "Citation": "pmid:32203200",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2020-07-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:30194086; pmid:29939203",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-04-01", "2018-08-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:39569876",
+      "Evidence detail": "Targeted long-read sequencing was performed in 77 FCMTE1 patients from 23 pedigrees; 73 SAMD12 (TTTTA)exp(TTTCA)exp alleles passed quality control for genotype analysis.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2025-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 2.0,
+      "Citation": "pmid:39569876",
+      "Evidence detail": "(TTTCA)exp counts in 73 FCMTE1 patients were inversely correlated with age at onset of cortical tremor and epilepsy, and increased during parental transmission, supporting a length-dependent pathogenic effect.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2025-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Computational",
+      "Score": 0.5,
+      "Citation": "pmid:32203200",
+      "Evidence detail": "Whole-genome sequencing repeat-expansion tools detected the SAMD12 TTTCA expansion in affected individuals from Sri Lankan and Indian FAME families and not in controls; RP-PCR validated the calls.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2020-07-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:30194086; pmid:29939203",
+      "Evidence detail": "PMID:30194086 reported complete cosegregation of SAMD12 TTTTA and inserted TTTCA expansions with FCMTE in a Chinese family, with additional cases in two families. PMID:29939203 reported cosegregation of the SAMD12 (TTTCA)n insertion in 18 Chinese pedigrees and absence in controls.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2019-04-01",
+        "2018-08-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 1.0,
-    "Citation": "pmid:29507423",
-    "Evidence detail": "RNA and transc reg",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2018-04-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 1.0,
-    "Citation": "pmid:29507423",
-    "Evidence detail": "decrease + mutant",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2018-04-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 1.0,
+      "Citation": "pmid:29507423",
+      "Evidence detail": "FISH of autopsied brains from SAMD12 expansion carriers showed UUUCA-containing RNA foci in cortical neurons and Purkinje cells, supporting repeat RNA-mediated toxicity.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2018-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 1.0,
+      "Citation": "pmid:29507423",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2018-04-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 0,
@@ -5815,8 +5829,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 2.0,
     "Genetic Evidence": 10.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5738,89 +5738,75 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:39569876",
-      "Evidence detail": "Targeted long-read sequencing was performed in 77 FCMTE1 patients from 23 pedigrees; 73 SAMD12 (TTTTA)exp(TTTCA)exp alleles passed quality control for genotype analysis.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2025-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 2.0,
-      "Citation": "pmid:39569876",
-      "Evidence detail": "(TTTCA)exp counts in 73 FCMTE1 patients were inversely correlated with age at onset of cortical tremor and epilepsy, and increased during parental transmission, supporting a length-dependent pathogenic effect.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2025-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Computational",
-      "Score": 0.5,
-      "Citation": "pmid:32203200",
-      "Evidence detail": "Whole-genome sequencing repeat-expansion tools detected the SAMD12 TTTCA expansion in affected individuals from Sri Lankan and Indian FAME families and not in controls; RP-PCR validated the calls.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2020-07-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:30194086; pmid:29939203",
-      "Evidence detail": "PMID:30194086 reported complete cosegregation of SAMD12 TTTTA and inserted TTTCA expansions with FCMTE in a Chinese family, with additional cases in two families. PMID:29939203 reported cosegregation of the SAMD12 (TTTCA)n insertion in 18 Chinese pedigrees and absence in controls.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2019-04-01",
-        "2018-08-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:39569876",
+    "Evidence detail": "Targeted long-read sequencing was performed in 77 FCMTE1 patients from 23 pedigrees; 73 SAMD12 (TTTTA)exp(TTTCA)exp alleles passed quality control for genotype analysis.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2025-02-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 2.0,
+    "Citation": "pmid:39569876",
+    "Evidence detail": "(TTTCA)exp counts in 73 FCMTE1 patients were inversely correlated with age at onset of cortical tremor and epilepsy, and increased during parental transmission, supporting a length-dependent pathogenic effect.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2025-02-01"]
+  },
+  {
+    "Evidence type": "Computational",
+    "Score": 0.5,
+    "Citation": "pmid:32203200",
+    "Evidence detail": "Whole-genome sequencing repeat-expansion tools detected the SAMD12 TTTCA expansion in affected individuals from Sri Lankan and Indian FAME families and not in controls; RP-PCR validated the calls.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2020-07-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:30194086; pmid:29939203",
+    "Evidence detail": "PMID:30194086 reported complete cosegregation of SAMD12 TTTTA and inserted TTTCA expansions with FCMTE in a Chinese family, with additional cases in two families. PMID:29939203 reported cosegregation of the SAMD12 (TTTCA)n insertion in 18 Chinese pedigrees and absence in controls.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2019-04-01", "2018-08-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 1.0,
-      "Citation": "pmid:29507423",
-      "Evidence detail": "FISH of autopsied brains from SAMD12 expansion carriers showed UUUCA-containing RNA foci in cortical neurons and Purkinje cells, supporting repeat RNA-mediated toxicity.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2018-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 1.0,
-      "Citation": "pmid:29507423",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2018-04-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 1.0,
+    "Citation": "pmid:29507423",
+    "Evidence detail": "FISH of autopsied brains from SAMD12 expansion carriers showed UUUCA-containing RNA foci in cortical neurons and Purkinje cells, supporting repeat RNA-mediated toxicity.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2018-04-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 1.0,
+    "Citation": "pmid:29507423",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2018-04-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 0,
@@ -5829,7 +5815,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 2.0,
     "Genetic Evidence": 10.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5795,10 +5795,10 @@
     "publication_dates": ["2018-04-01"]
   },
   {
-    "Evidence type": "Protein interaction",
-    "Score": 1.0,
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
     "Citation": "pmid:29507423",
-    "Evidence detail": "",
+    "Evidence detail": "PMID 29507423 supports reduced SAMD12 protein levels in patient brains.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,

--- a/scripts/check-curations.py
+++ b/scripts/check-curations.py
@@ -305,7 +305,20 @@ def summarize_curations(locus):
     """
     # Add publication year for each citation
     all_pub_dates = []
-    for evidence_entry in locus.get('genetic_evidence_details', []) + locus.get('experimental_evidence_details', []):
+    genetic_entries = []
+    for evidence_entry in locus.get('genetic_evidence_details', []):
+        entry = dict(evidence_entry)
+        entry['__original_section'] = 'genetic'
+        genetic_entries.append(entry)
+
+    experimental_entries = []
+    for evidence_entry in locus.get('experimental_evidence_details', []):
+        entry = dict(evidence_entry)
+        entry['__original_section'] = 'experimental'
+        experimental_entries.append(entry)
+
+    combined_entries = genetic_entries + experimental_entries
+    for evidence_entry in combined_entries:
         citations = evidence_entry.get('Citation', None)
         publication_dates = evidence_entry.get('publication_dates', [])
         if citations is None:
@@ -316,7 +329,7 @@ def summarize_curations(locus):
         all_pub_dates.extend(publication_dates)
 
     locus_id = locus.get('Locus_ID', 'Unknown Locus')
-    df = pd.DataFrame(locus.get('genetic_evidence_details', []) + locus.get('experimental_evidence_details', []))
+    df = pd.DataFrame(combined_entries)
 
     #sys.stdout.write(f"Processing locus '{locus_id}' with {len(df)} evidence entries...\n")
     if len(df) == 0:
@@ -326,10 +339,11 @@ def summarize_curations(locus):
     # Re-apply evidence category/supercategory from EVIDENCE_LOOKUP to fix stale or null values
     for idx, row in df.iterrows():
         mapping = NORMALIZED_EVIDENCE_LOOKUP.get(_normalize_evidence_type(row.get('Evidence type')), {})
-        df.at[idx, 'evidence_category'] = mapping.get('evidence_category')
-        df.at[idx, 'evidence_supercategory'] = mapping.get('evidence_supercategory')
-        df.at[idx, 'evidence_max_score'] = mapping.get('evidence_max_score')
-        df.at[idx, 'category_max_score'] = mapping.get('category_max_score')
+        if mapping:
+            df.at[idx, 'evidence_category'] = mapping.get('evidence_category')
+            df.at[idx, 'evidence_supercategory'] = mapping.get('evidence_supercategory')
+            df.at[idx, 'evidence_max_score'] = mapping.get('evidence_max_score')
+            df.at[idx, 'category_max_score'] = mapping.get('category_max_score')
 
     # Report any evidence types that are not recognized in the EVIDENCE_LOOKUP
     for evidence_type in df['Evidence type'].unique():
@@ -406,8 +420,25 @@ def summarize_curations(locus):
         publication_interval_years = None
 
     # Collect the Genetic and Experimental evidence details for the curation
-    genetic_evidence_details = df[df['evidence_supercategory'] == 'Genetic Evidence'].to_dict(orient='records')
-    experimental_evidence_details = df[df['evidence_supercategory'] == 'Experimental Evidence'].to_dict(orient='records')
+    genetic_df = df[df['evidence_supercategory'] == 'Genetic Evidence']
+    experimental_df = df[df['evidence_supercategory'] == 'Experimental Evidence']
+    unknown_df = df[~df['evidence_supercategory'].isin(['Genetic Evidence', 'Experimental Evidence'])]
+
+    if len(unknown_df) > 0:
+        sys.stderr.write(
+            f"Warning: {len(unknown_df)} evidence entries have missing/unrecognized supercategory in locus '{locus_id}'. Preserving in original section.\n"
+        )
+        genetic_df = pd.concat(
+            [genetic_df, unknown_df[unknown_df['__original_section'] == 'genetic']],
+            ignore_index=True
+        )
+        experimental_df = pd.concat(
+            [experimental_df, unknown_df[unknown_df['__original_section'] == 'experimental']],
+            ignore_index=True
+        )
+
+    genetic_evidence_details = genetic_df.drop(columns=['__original_section'], errors='ignore').to_dict(orient='records')
+    experimental_evidence_details = experimental_df.drop(columns=['__original_section'], errors='ignore').to_dict(orient='records')
 
     # Return updated dictionary containing the curation summary
     locus["category_summary"] = category_summary


### PR DESCRIPTION
Description

Updated the SAMD12_FAME1 criTRia entry by filling the root-level Description and improving vague/null Evidence detail fields while preserving scores, evidence rows, summaries, total score, classification, and schema.

Fixes: #

Major Changes
None
Minor Changes
Added concise FAME1/SAMD12 locus-level description.
Updated evidence details for probands, allele correlation, computational evidence, segregation, and biochemical function.
Added curator-review note to the existing Protein interaction row because PMID:29507423 does not appear to support a protein interaction assay.
Preserved all existing scores and summary fields from the original JSON.
Checklist
 All changes are well summarized
 Check all tests pass
 Check that the website preview looks good
 Update the STRchive version in CITATION.cff, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
 Ask someone to review this PR