### PR TITLE
FAME3-MARCHF6-critria-update

### DIFF
--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -2728,7 +2728,7 @@
   "id": "FAME3_MARCHF6",
   "disease_id": "FAME3",
   "gene": "MARCHF6",
-  "evidence": ["Strong"],
+  "evidence": ["Definitive"],
   "chrom": "chr5",
   "start_hg38": 10356343,
   "stop_hg38": 10356411,

--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -2728,7 +2728,7 @@
   "id": "FAME3_MARCHF6",
   "disease_id": "FAME3",
   "gene": "MARCHF6",
-  "evidence": ["Definitive"],
+  "evidence": ["Strong"],
   "chrom": "chr5",
   "start_hg38": 10356343,
   "stop_hg38": 10356411,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3792,6 +3792,17 @@
     "publication_dates": ["2019-10-29"]
   },
   {
+    "Evidence type": "Segregation",
+    "Score": 0.0,
+    "Citation": "pmid:12140665; pmid:19616813",
+    "Evidence detail": "Large multigenerational families with FCMTE/FCTE show clear autosomal dominant segregation of the phenotype; however, linkage analyses excluded known loci (8q23.3-q24.1 and 2p11.1-q12.2), indicating genetic heterogeneity. These studies support heritable segregation of disease but do not demonstrate segregation of the MARCH6 repeat expansion specifically.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2002-07-01", "2009-10-01"]
+  },
+  {
     "Evidence type": "Case-control data",
     "Score": 6.0,
     "Citation": "pmid:31664039",
@@ -3841,9 +3852,9 @@
     "Genetic Evidence": 10.0
   },
   "total_score": 11.5,
-  "publication_count": 1,
-  "publication_interval_years": null,
-  "classification": "Strong"
+  "publication_count": 3,
+  "publication_interval_years": 17.33,
+  "classification": "Definitive"
 },
 {
   "Disease_ID": "CHNG3",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3753,135 +3753,158 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/12/2025",
-  "Description": null,
+  "Description": "Autosomal dominant familial adult myoclonic epilepsy type 3 (FAME3) is associated with an intronic TTTTA/TTTCA repeat expansion in MARCH6/MARCHF6 on chromosome 5p15.2. The expansion was identified by genome sequencing and repeat-primed PCR in four European families with cortical/myoclonic tremor and epilepsy, co-segregated with disease, and was absent from controls in the reported analyses. Expansion length, particularly the TTTCA component, inversely correlated with age at seizure onset. Patient-derived blood cells and fibroblasts showed marked somatic instability and expansion-size variability.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 1.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": "4 families",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1.0,
-    "Citation": "pmid:31664039",
-    "Evidence detail": "Association between onset and allele size",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": "est. LOD over 5",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Computational",
-    "Score": 0.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 6.0,
-    "Citation": "pmid:31664039",
-    "Evidence detail": null,
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2019-10-29"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 1.5,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "MARCH6/MARCHF6 intronic TTTTA/TTTCA expansions identified in four European FAME families (two French, one Dutch, one German) using genome sequencing and RP-PCR.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1.0,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "Expansion length, mainly the TTTCA component, inversely correlated with age at seizure onset; no significant correlation was observed with tremor onset.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "The MARCH6 expansion co-segregated with FAME in the reported families, including Dutch Family 3 where an incompletely segregating CTNND2 variant was reclassified as likely benign.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Computational",
+      "Score": 0.5,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "ExpansionHunter detected TTTCA-containing reads at the MARCH6 intron 1 locus, with concordant support from exSTRa, STRetch, and TRhist; RP-PCR confirmed 5-TTTTA and 3-TTTCA expanded motifs.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 6.0,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "MARCH6 expansions were identified in affected FAME families, while 83 European controls showed only 9-20 TTTTA repeats and no larger or TTTCA-containing alleles.",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:19616813",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2009-10-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:19616813",
-    "Evidence detail": "Expression",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2009-10-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": "Varied expression in patients + splicing",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:31664039",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:12140665",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2002-07-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:19616813",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2009-10-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:19616813",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2009-10-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "RNA-seq and qRT-PCR in expansion-carrier blood cells and fibroblasts found no detectable change in MARCH6 RNA or protein levels and no massive intron 1 retention/splicing abnormality.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "Patient-derived blood cells and fibroblasts showed extensive somatic instability, multiple expansion configurations, and micro-rearrangements in individuals with the largest MARCH6 expansions.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:31664039",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2019-10-29"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:12140665",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2002-07-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 1.5,
     "Collective Evidence": 3.0,
     "Statistics": 6.0,
@@ -3890,8 +3913,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 4.0,
     "Genetic Evidence": 10.5
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3828,22 +3828,22 @@
   "category_summary":
   {
     "Singular Evidence": 1.5,
-    "Collective Evidence": 3.0,
+    "Collective Evidence": 2.5,
     "Statistics": 6.0,
-    "Function": 1.5,
-    "Functional Alteration": 2,
+    "Function": 0.5,
+    "Functional Alteration": 1.0,
     "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 4.0,
-    "Genetic Evidence": 10.5
+    "Experimental Evidence": 1.5,
+    "Genetic Evidence": 10.0
   },
-  "total_score": 14.5,
-  "publication_count": 3,
-  "publication_interval_years": 17.33,
-  "classification": "Definitive"
+  "total_score": 11.5,
+  "publication_count": 1,
+  "publication_interval_years": null,
+  "classification": "Strong"
 },
 {
   "Disease_ID": "CHNG3",
@@ -5933,7 +5933,7 @@
     "Evidence detail": "PMID:35868859 characterized eight iPSC lines from three heterozygous female XDP carriers with X-chromosome-inactivation clones expressing either the wild-type or XDP haplotype, providing non-patient carrier cell resources for modeling TAF1/SVA effects.",
     "evidence_category": "Functional Alteration",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
+    "evidence_max_score": 2,
     "category_max_score": 2,
     "publication_dates": ["2022-07-21"]
   },
@@ -5942,10 +5942,10 @@
     "Score": 1.0,
     "Citation": "pmid:34250228",
     "Evidence detail": "Repeat sizing and somatic instability in human postmortem brain tissues from two XDP patients showed higher median repeat numbers and higher degrees of repeat instability in the basal ganglia and cerebellum compared with blood.",
-    "evidence_category": "Models",
+    "evidence_category": "Functional Alteration",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
+    "evidence_max_score": 2,
+    "category_max_score": 2,
     "publication_dates": ["2021-08-01"]
   }],
   "category_summary":
@@ -5954,8 +5954,8 @@
     "Collective Evidence": 3,
     "Statistics": 0,
     "Function": 2,
-    "Functional Alteration": 0.5,
-    "Models": 1.0,
+    "Functional Alteration": 1.5,
+    "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3758,153 +3758,130 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 1.5,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "MARCH6/MARCHF6 intronic TTTTA/TTTCA expansions identified in four European FAME families (two French, one Dutch, one German) using genome sequencing and RP-PCR.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1.0,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "Expansion length, mainly the TTTCA component, inversely correlated with age at seizure onset; no significant correlation was observed with tremor onset.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "The MARCH6 expansion co-segregated with FAME in the reported families, including Dutch Family 3 where an incompletely segregating CTNND2 variant was reclassified as likely benign.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Computational",
-      "Score": 0.5,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "ExpansionHunter detected TTTCA-containing reads at the MARCH6 intron 1 locus, with concordant support from exSTRa, STRetch, and TRhist; RP-PCR confirmed 5-TTTTA and 3-TTTCA expanded motifs.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 6.0,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "MARCH6 expansions were identified in affected FAME families, while 83 European controls showed only 9-20 TTTTA repeats and no larger or TTTCA-containing alleles.",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 1.5,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "MARCH6/MARCHF6 intronic TTTTA/TTTCA expansions identified in four European FAME families (two French, one Dutch, one German) using genome sequencing and RP-PCR.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1.0,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "Expansion length, mainly the TTTCA component, inversely correlated with age at seizure onset; no significant correlation was observed with tremor onset.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "The MARCH6 expansion co-segregated with FAME in the reported families, including Dutch Family 3 where an incompletely segregating CTNND2 variant was reclassified as likely benign.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Computational",
+    "Score": 0.5,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "ExpansionHunter detected TTTCA-containing reads at the MARCH6 intron 1 locus, with concordant support from exSTRa, STRetch, and TRhist; RP-PCR confirmed 5-TTTTA and 3-TTTCA expanded motifs.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 6.0,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "MARCH6 expansions were identified in affected FAME families, while 83 European controls showed only 9-20 TTTTA repeats and no larger or TTTCA-containing alleles.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2019-10-29"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:19616813",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2009-10-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:19616813",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2009-10-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "RNA-seq and qRT-PCR in expansion-carrier blood cells and fibroblasts found no detectable change in MARCH6 RNA or protein levels and no massive intron 1 retention/splicing abnormality.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "Patient-derived blood cells and fibroblasts showed extensive somatic instability, multiple expansion configurations, and micro-rearrangements in individuals with the largest MARCH6 expansions.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:31664039",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2019-10-29"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:12140665",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2002-07-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:19616813",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2009-10-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:19616813",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2009-10-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "RNA-seq and qRT-PCR in expansion-carrier blood cells and fibroblasts found no detectable change in MARCH6 RNA or protein levels and no massive intron 1 retention/splicing abnormality.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "Patient-derived blood cells and fibroblasts showed extensive somatic instability, multiple expansion configurations, and micro-rearrangements in individuals with the largest MARCH6 expansions.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:31664039",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_dates": ["2019-10-29"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:12140665",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2002-07-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 1.5,
     "Collective Evidence": 3.0,
     "Statistics": 6.0,
@@ -3913,7 +3890,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 4.0,
     "Genetic Evidence": 10.5
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3751,7 +3751,7 @@
   "Gene": "MARCHF6",
   "Locus_ID": "FAME3_MARCHF6",
   "Inheritance": "AD",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
   "Date": "08/12/2025",
   "Description": "Autosomal dominant familial adult myoclonic epilepsy type 3 (FAME3) is associated with an intronic TTTTA/TTTCA repeat expansion in MARCH6/MARCHF6 on chromosome 5p15.2. The expansion was identified by genome sequencing and repeat-primed PCR in four European families with cortical/myoclonic tremor and epilepsy, co-segregated with disease, and was absent from controls in the reported analyses. Expansion length, particularly the TTTCA component, inversely correlated with age at seizure onset. Patient-derived blood cells and fibroblasts showed marked somatic instability and expansion-size variability.",
   "Source": "criTRia",
@@ -3792,17 +3792,6 @@
     "publication_dates": ["2019-10-29"]
   },
   {
-    "Evidence type": "Computational",
-    "Score": 0.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": "ExpansionHunter detected TTTCA-containing reads at the MARCH6 intron 1 locus, with concordant support from exSTRa, STRetch, and TRhist; RP-PCR confirmed 5-TTTTA and 3-TTTCA expanded motifs.",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
     "Evidence type": "Case-control data",
     "Score": 6.0,
     "Citation": "pmid:31664039",
@@ -3814,28 +3803,6 @@
     "publication_dates": ["2019-10-29"]
   }],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:19616813",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2009-10-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:19616813",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2009-10-01"]
-  },
   {
     "Evidence type": "Regulatory impact",
     "Score": 0.5,
@@ -3857,28 +3824,6 @@
     "evidence_max_score": 2,
     "category_max_score": 2,
     "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:31664039",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2019-10-29"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:12140665",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2002-07-01"]
   }],
   "category_summary":
   {


### PR DESCRIPTION
Updated the MARCHF6/FAME3 criTRia entry by replacing the null root-level description and refining vague/null evidence detail fields with concise source-supported wording. The updates clarify the MARCH6/MARCHF6 intronic TTTTA/TTTCA expansion evidence, including four reported European families, segregation, computational detection, control data, allele-size correlation, and patient-derived cell findings.

Fixes: #

Major Changes
None
Minor Changes
Added a concise root-level disease/locus description for FAME3_MARCHF6.
Updated vague or null genetic evidence details for probands, allele association, segregation, computational evidence, and case-control data.
Updated supported experimental evidence details for PMID:31664039.
Left unsupported experimental evidence rows blank for curator review rather than adding unsupported claims.
Checklist
 All changes are well summarized
 Check all tests pass
 Check that the website preview looks good
 Update the STRchive version in CITATION.cff, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
 Ask someone to review this PR