### PR TITLE
FAME4_YEATS2-citria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6765,75 +6765,64 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 1.5,
-      "Citation": "pmid:31539032",
-      "Evidence detail": "One Thai BAFME4 family/proband: long-read sequencing identified an intronic YEATS2 (TTTTA)n expansion with TTTCA insertion; RP-PCR and long-range PCR confirmed expanded alleles in affected family members, with TTTCA absent from unaffected relatives and 1116 Thai controls.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2019-11-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:22713812",
-      "Evidence detail": "Genome-wide linkage in a Thai autosomal dominant BAFME family with 13 affected members mapped disease to chromosome 3q26.32-q28; D3S1262 had maximum two-point LOD 5.419 at θ=0, refined to a 10 Mb interval between D3S3730 and D3S1580.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2013-02-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 1.5,
+    "Citation": "pmid:31539032",
+    "Evidence detail": "One Thai BAFME4 family/proband: long-read sequencing identified an intronic YEATS2 (TTTTA)n expansion with TTTCA insertion; RP-PCR and long-range PCR confirmed expanded alleles in affected family members, with TTTCA absent from unaffected relatives and 1116 Thai controls.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2019-11-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:22713812",
+    "Evidence detail": "Genome-wide linkage in a Thai autosomal dominant BAFME family with 13 affected members mapped disease to chromosome 3q26.32-q28; D3S1262 had maximum two-point LOD 5.419 at θ=0, refined to a 10 Mb interval between D3S3730 and D3S1580.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2013-02-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:38128822",
-      "Evidence detail": "Gene-level evidence: pan-neuronal dYEATS2 knockdown in Drosophila reduced dopamine content and lowered tyrosine hydroxylase transcript/protein levels, supporting a role for YEATS2 in dopamine biosynthesis; the human repeat expansion was not directly modeled.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:38128822",
-      "Evidence detail": "Gene-level expression evidence: dYEATS2 knockdown altered dopaminergic pathway expression markers, including reduced tyrosine hydroxylase and changes in vMAT/D2R; the study did not directly test regulatory effects of the human intronic TTTTA/TTTCA expansion.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:38128822",
-      "Evidence detail": "Drosophila pan-neuronal dYEATS2 knockdown caused seizure-like behaviours after electric, thermal, and mechanical stress, with locomotor/social/exploratory deficits; L-DOPA improved seizure-like and exploratory phenotypes. This models YEATS2 loss of function, not the human repeat expansion.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:38128822",
+    "Evidence detail": "Gene-level evidence: pan-neuronal dYEATS2 knockdown in Drosophila reduced dopamine content and lowered tyrosine hydroxylase transcript/protein levels, supporting a role for YEATS2 in dopamine biosynthesis; the human repeat expansion was not directly modeled.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-02-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:38128822",
+    "Evidence detail": "Gene-level expression evidence: dYEATS2 knockdown altered dopaminergic pathway expression markers, including reduced tyrosine hydroxylase and changes in vMAT/D2R; the study did not directly test regulatory effects of the human intronic TTTTA/TTTCA expansion.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-02-01"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:38128822",
+    "Evidence detail": "Drosophila pan-neuronal dYEATS2 knockdown caused seizure-like behaviours after electric, thermal, and mechanical stress, with locomotor/social/exploratory deficits; L-DOPA improved seizure-like and exploratory phenotypes. This models YEATS2 loss of function, not the human repeat expansion.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2024-02-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -6842,7 +6831,8 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 3.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6758,71 +6758,82 @@
   "Gene": "YEATS2",
   "Locus_ID": "FAME4_YEATS2",
   "Inheritance": "AD",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Elbay Aliyev",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "Familial adult myoclonic epilepsy type 4 (FAME4) is an autosomal dominant disorder associated with intronic YEATS2 pentanucleotide repeat expansion/insertion. In a Thai BAFME4 family, long-read sequencing identified a YEATS2 intron 1 (TTTTA)n expansion with a TTTCA insertion, and RP-PCR/long-range PCR showed segregation of TTTCA insertions with disease in 13 affected relatives and absence from eight unaffected relatives and 1116 Thai controls. Earlier linkage mapped the disease locus to 3q26.32-q28. Gene-level Drosophila knockdown studies support a neuronal role for YEATS2.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 1.5,
-    "Citation": "pmid:31539032",
-    "Evidence detail": "1 proband",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2019-11-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:22713812",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2013-02-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 1.5,
+      "Citation": "pmid:31539032",
+      "Evidence detail": "One Thai BAFME4 family/proband: long-read sequencing identified an intronic YEATS2 (TTTTA)n expansion with TTTCA insertion; RP-PCR and long-range PCR confirmed expanded alleles in affected family members, with TTTCA absent from unaffected relatives and 1116 Thai controls.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2019-11-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:22713812",
+      "Evidence detail": "Genome-wide linkage in a Thai autosomal dominant BAFME family with 13 affected members mapped disease to chromosome 3q26.32-q28; D3S1262 had maximum two-point LOD 5.419 at θ=0, refined to a 10 Mb interval between D3S3730 and D3S1580.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2013-02-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:38128822",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-02-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:38128822",
-    "Evidence detail": "expression",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-02-01"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:38128822",
-    "Evidence detail": "fly",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2024-02-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:38128822",
+      "Evidence detail": "Gene-level evidence: pan-neuronal dYEATS2 knockdown in Drosophila reduced dopamine content and lowered tyrosine hydroxylase transcript/protein levels, supporting a role for YEATS2 in dopamine biosynthesis; the human repeat expansion was not directly modeled.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:38128822",
+      "Evidence detail": "Gene-level expression evidence: dYEATS2 knockdown altered dopaminergic pathway expression markers, including reduced tyrosine hydroxylase and changes in vMAT/D2R; the study did not directly test regulatory effects of the human intronic TTTTA/TTTCA expansion.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:38128822",
+      "Evidence detail": "Drosophila pan-neuronal dYEATS2 knockdown caused seizure-like behaviours after electric, thermal, and mechanical stress, with locomotor/social/exploratory deficits; L-DOPA improved seizure-like and exploratory phenotypes. This models YEATS2 loss of function, not the human repeat expansion.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -6831,8 +6842,7 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 3.0
   },


### PR DESCRIPTION
## Description

Updated the YEATS2_FAME4 criTRia entry by replacing null/vague evidence details with concise source-supported descriptions and adding a root-level disease/locus description.

Fixes: # **Link to any relevant issues and/or discussions**

## Major Changes

* None

## Minor Changes

* Added FAME4/YЕATS2 description summarizing the intronic TTTTA/TTTCA repeat expansion, Thai family segregation, linkage evidence, and gene-level Drosophila support.
* Clarified existing evidence details for proband, segregation, biochemical function, regulatory impact, and non-human model organism rows.
* Added curator name to the existing curator field.
* No scores, summaries, classification, publication count, or evidence rows were changed. 

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
