### PR TITLE
FAME6_TNRC6A-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6501,7 +6501,7 @@
   "Gene": "TNRC6A",
   "Locus_ID": "FAME6_TNRC6A",
   "Inheritance": "AD",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
   "Date": "08/14/2025",
   "Description": "FAME6/BAFME6 is an autosomal dominant familial adult myoclonic epilepsy phenotype associated with noncoding TTTCA and TTTTA repeat expansions in TNRC6A. PMID:29507423 identified TNRC6A expansions in one BAFME family (F9283), confirmed the repeat configuration by RP-PCR and Southern blot, and reported co-segregation in five affected individuals and one unaffected individual. TTTCA-repeat expansions in TNRC6A were absent from 1,000 control subjects, while TTTTA-only expansions were observed rarely in controls, supporting the TTTCA-containing expanded allele as the disease-relevant motif.",
   "Source": "criTRia",
@@ -6533,9 +6533,9 @@
   "experimental_evidence_details": [
   {
     "Evidence type": "Regulatory impact",
-    "Score": 0.5,
+    "Score": 0.2,
     "Citation": "pmid:29507423",
-    "Evidence detail": "",
+    "Evidence detail": "In the supplementary materials of pmid:29507423 RNA-seq data from control brains show that TNRC6A is transcribed with spliced transcripts flanking the repeat, and RT-PCR confirms expression in brain and other tissues; however, no differential expression or regulatory effect of the repeat expansion is demonstrated. Downgraded score to 0.2 as the evidence does not assess the impact of the expansion on gene function.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6503,47 +6503,54 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/14/2025",
-  "Description": null,
+  "Description": "FAME6/BAFME6 is an autosomal dominant familial adult myoclonic epilepsy phenotype associated with noncoding TTTCA and TTTTA repeat expansions in TNRC6A. PMID:29507423 identified TNRC6A expansions in one BAFME family (F9283), confirmed the repeat configuration by RP-PCR and Southern blot, and reported co-segregation in five affected individuals and one unaffected individual. TTTCA-repeat expansions in TNRC6A were absent from 1,000 control subjects, while TTTTA-only expansions were observed rarely in controls, supporting the TTTCA-containing expanded allele as the disease-relevant motif.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 1.5,
-    "Citation": "pmid:29507423",
-    "Evidence detail": "1.0",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2018-04-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1.0,
-    "Citation": "pmid:29507423",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2018-04-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 1.5,
+      "Citation": "pmid:29507423",
+      "Evidence detail": "One unrelated BAFME6 family (F9283) with five affected individuals carried TNRC6A TTTCA/TTTTA repeat expansions; the expanded allele was validated by RP-PCR and Southern blot and co-segregated with disease.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2018-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1.0,
+      "Citation": "pmid:29507423",
+      "Evidence detail": "TNRC6A TTTCA-repeat expansions were absent in 1,000 controls and in patients with SAMD12 expansions; TTTTA-only expansions occurred rarely in controls, supporting the TTTCA-containing expanded motif as disease-relevant.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2018-04-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:29507423",
-    "Evidence detail": "issue specific expression data in supplementary, \"control brains\"",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2018-04-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:29507423",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2018-04-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.0,
     "Statistics": 0,
@@ -6552,8 +6559,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 0.5,
     "Genetic Evidence": 2.5
   },
@@ -6561,7 +6567,8 @@
   "publication_count": 1,
   "publication_interval_years": null,
   "classification": "Limited"
-},
+}
+,
 {
   "Disease_ID": "HMNR7",
   "Gene": "VWA1",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6508,49 +6508,42 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 1.5,
-      "Citation": "pmid:29507423",
-      "Evidence detail": "One unrelated BAFME6 family (F9283) with five affected individuals carried TNRC6A TTTCA/TTTTA repeat expansions; the expanded allele was validated by RP-PCR and Southern blot and co-segregated with disease.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2018-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1.0,
-      "Citation": "pmid:29507423",
-      "Evidence detail": "TNRC6A TTTCA-repeat expansions were absent in 1,000 controls and in patients with SAMD12 expansions; TTTTA-only expansions occurred rarely in controls, supporting the TTTCA-containing expanded motif as disease-relevant.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2018-04-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 1.5,
+    "Citation": "pmid:29507423",
+    "Evidence detail": "One unrelated BAFME6 family (F9283) with five affected individuals carried TNRC6A TTTCA/TTTTA repeat expansions; the expanded allele was validated by RP-PCR and Southern blot and co-segregated with disease.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2018-04-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1.0,
+    "Citation": "pmid:29507423",
+    "Evidence detail": "TNRC6A TTTCA-repeat expansions were absent in 1,000 controls and in patients with SAMD12 expansions; TTTTA-only expansions occurred rarely in controls, supporting the TTTCA-containing expanded motif as disease-relevant.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2018-04-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:29507423",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2018-04-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:29507423",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2018-04-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.0,
     "Statistics": 0,
@@ -6559,7 +6552,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 0.5,
     "Genetic Evidence": 2.5
   },
@@ -6567,8 +6561,7 @@
   "publication_count": 1,
   "publication_interval_years": null,
   "classification": "Limited"
-}
-,
+},
 {
   "Disease_ID": "HMNR7",
   "Gene": "VWA1",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6547,17 +6547,17 @@
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.0,
     "Statistics": 0,
-    "Function": 0.5,
+    "Function": 0.2,
     "Functional Alteration": 0,
     "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 0.5,
+    "Experimental Evidence": 0.2,
     "Genetic Evidence": 2.5
   },
-  "total_score": 3.0,
+  "total_score": 2.7,
   "publication_count": 1,
   "publication_interval_years": null,
   "classification": "Limited"


### PR DESCRIPTION
## Description

Updated the TNRC6A/FAME6 criTRia entry by adding a concise locus-level description and improving incomplete evidence-detail fields based on PMID:29507423. The updated entry now describes the F9283 BAFME6 family, TNRC6A TTTCA/TTTTA expansion validation, segregation, and control observations. 

Fixes: #

## Major Changes

* None

## Minor Changes

* Added root-level `Description` for TNRC6A/FAME6.
* Updated Probands evidence detail from vague value `"1.0"` to a concise summary of the affected F9283 family and validation methods.
* Updated Allele evidence detail from `null` to a concise control/allele-specific summary.
* Cleared unsupported/vague Regulatory impact detail pending curator review; no scores or summary fields were changed.  

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
