### PR TITLE
RAPGEF2_FAME7-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5418,36 +5418,41 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/14/2025",
-  "Description": null,
+  "Description": "Intronic TTTCA repeat expansions in RAPGEF2 have been reported in autosomal dominant familial adult myoclonic epilepsy/familial cortical myoclonic tremor with epilepsy (FAME7/BAFME7/FCMTE). Evidence includes one Japanese BAFME family (F8241) with a RAPGEF2 intron 14 TTTCA expansion confirmed by WGS, RP-PCR and Southern blot, and one Chinese FCMTE family with RAPGEF2 TTTCA expansion detected by RP-PCR. Expanded TTTCA repeats in RAPGEF2 were absent from tested controls, but no RAPGEF2-specific experimental evidence has been reported; current classification remains Limited.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 2,
-    "Citation": "pmid:30351492; pmid:29507423",
-    "Evidence detail": "Family but no functional evdience | 1.0",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2019-03-01", "2018-04-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1,
-    "Citation": "pmid:30351492",
-    "Evidence detail": "Motif",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2019-03-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 2,
+      "Citation": "pmid:30351492; pmid:29507423",
+      "Evidence detail": "Two unrelated autosomal dominant FAME/BAFME/FCMTE families with RAPGEF2 intronic TTTCA repeat expansions: Japanese family F8241 with one affected proband confirmed by WGS, RP-PCR and Southern blot, and Chinese family 3 with three affected individuals carrying ~60 TTTCA repeats by RP-PCR. No RAPGEF2-specific functional evidence was reported.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2019-03-01",
+        "2018-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1,
+      "Citation": "pmid:30351492",
+      "Evidence detail": "RAPGEF2 disease alleles in Chinese family 3 carried an expanded TTTCA motif (~60 repeats) without detectable TTTTA expansion; expanded TTTCA/TTTTA repeats in SAMD12 or RAPGEF2 were absent from 116 control alleles.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2019-03-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [],
-  "category_summary":
-  {
+  "category_summary": {
     "Singular Evidence": 2,
     "Collective Evidence": 1,
     "Statistics": 0,
@@ -5456,8 +5461,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Genetic Evidence": 3,
     "Experimental Evidence": 0
   },
@@ -5465,7 +5469,8 @@
   "publication_count": 2,
   "publication_interval_years": 0.91,
   "classification": "Limited"
-},
+}
+,
 {
   "Disease_ID": "CANVAS",
   "Gene": "RFC1",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5423,36 +5423,31 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 2,
-      "Citation": "pmid:30351492; pmid:29507423",
-      "Evidence detail": "Two unrelated autosomal dominant FAME/BAFME/FCMTE families with RAPGEF2 intronic TTTCA repeat expansions: Japanese family F8241 with one affected proband confirmed by WGS, RP-PCR and Southern blot, and Chinese family 3 with three affected individuals carrying ~60 TTTCA repeats by RP-PCR. No RAPGEF2-specific functional evidence was reported.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2019-03-01",
-        "2018-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1,
-      "Citation": "pmid:30351492",
-      "Evidence detail": "RAPGEF2 disease alleles in Chinese family 3 carried an expanded TTTCA motif (~60 repeats) without detectable TTTTA expansion; expanded TTTCA/TTTTA repeats in SAMD12 or RAPGEF2 were absent from 116 control alleles.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2019-03-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 2,
+    "Citation": "pmid:30351492; pmid:29507423",
+    "Evidence detail": "Two unrelated autosomal dominant FAME/BAFME/FCMTE families with RAPGEF2 intronic TTTCA repeat expansions: Japanese family F8241 with one affected proband confirmed by WGS, RP-PCR and Southern blot, and Chinese family 3 with three affected individuals carrying ~60 TTTCA repeats by RP-PCR. No RAPGEF2-specific functional evidence was reported.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2019-03-01", "2018-04-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1,
+    "Citation": "pmid:30351492",
+    "Evidence detail": "RAPGEF2 disease alleles in Chinese family 3 carried an expanded TTTCA motif (~60 repeats) without detectable TTTTA expansion; expanded TTTCA/TTTTA repeats in SAMD12 or RAPGEF2 were absent from 116 control alleles.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2019-03-01"]
+  }],
   "experimental_evidence_details": [],
-  "category_summary": {
+  "category_summary":
+  {
     "Singular Evidence": 2,
     "Collective Evidence": 1,
     "Statistics": 0,
@@ -5461,7 +5456,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Genetic Evidence": 3,
     "Experimental Evidence": 0
   },
@@ -5469,8 +5465,7 @@
   "publication_count": 2,
   "publication_interval_years": 0.91,
   "classification": "Limited"
-}
-,
+},
 {
   "Disease_ID": "CANVAS",
   "Gene": "RFC1",


### PR DESCRIPTION
## Description

Updated the RAPGEF2_FAME7 criTRia entry by adding a concise locus-level description and replacing vague evidence details with PMID-supported summaries for RAPGEF2 intronic TTTCA repeat expansion evidence. Scores, classification, summaries, and schema were unchanged. :contentReference[oaicite:0]{index=0}

Fixes: #

## Major Changes

- None

## Minor Changes

- Added root-level `Description` for RAPGEF2_FAME7.
- Updated Probands evidence detail to summarize two unrelated FAME/BAFME/FCMTE families with RAPGEF2 intronic TTTCA repeat expansions.
- Updated Allele evidence detail to clarify the ~60 TTTCA repeat motif in the Chinese RAPGEF2 family and absence from tested controls.
- Preserved existing scores, category summaries, total score, publication count, classification, and evidence rows. :contentReference[oaicite:1]{index=1} :contentReference[oaicite:2]{index=2}

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR