### PR TITLE
ZNF713_FRA7A-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -7117,35 +7117,31 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 3,
-      "Citation": "pmid:25196122",
-      "Evidence detail": "Two unrelated ASD families were described: Family 7,792 had one male proband with a maternally derived FRA7A full CGG expansion (>450 repeats), CpG methylation, and reduced ZNF713 expression; Family TCAG0070 had three affected siblings carrying paternal FRA7A premutation alleles with partial/mosaic methylation, mitotic instability in one sibling, and ZNF713 dysregulation.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2014-11-01"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 4,
-      "Citation": "pmid:25196122",
-      "Evidence detail": "PCR sizing of 176 controls showed 14 normal alleles (5–22 CGG repeats) and no premutation-range alleles; no additional FRA7A cases were detected in >9,000 neurodevelopmental cytogenetic analyses. Controls were not phenotype-matched and the PCR assay could miss heterozygous full expansions, so support is imperfect.",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "2014-11-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 3,
+    "Citation": "pmid:25196122",
+    "Evidence detail": "Two unrelated ASD families were described: Family 7,792 had one male proband with a maternally derived FRA7A full CGG expansion (>450 repeats), CpG methylation, and reduced ZNF713 expression; Family TCAG0070 had three affected siblings carrying paternal FRA7A premutation alleles with partial/mosaic methylation, mitotic instability in one sibling, and ZNF713 dysregulation.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2014-11-01"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 4,
+    "Citation": "pmid:25196122",
+    "Evidence detail": "PCR sizing of 176 controls showed 14 normal alleles (5–22 CGG repeats) and no premutation-range alleles; no additional FRA7A cases were detected in >9,000 neurodevelopmental cytogenetic analyses. Controls were not phenotype-matched and the PCR assay could miss heterozygous full expansions, so support is imperfect.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2014-11-01"]
+  }],
   "experimental_evidence_details": [],
-  "category_summary": {
+  "category_summary":
+  {
     "Singular Evidence": 3,
     "Collective Evidence": 0,
     "Statistics": 4,
@@ -7154,7 +7150,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Genetic Evidence": 7,
     "Experimental Evidence": 0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -7112,36 +7112,40 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "A CGG-repeat expansion at the folate-sensitive fragile site FRA7A lies in the first intron/5' region of ZNF713 and was reported in association with autistic spectrum disorder (ASD). One male proband had a maternally derived full expansion (>450 CGGs) with CpG island hypermethylation and reduced ZNF713 expression, and a second unrelated ASD family had three affected siblings carrying paternal FRA7A premutation alleles with partial/mosaic methylation, mitotic instability, and ZNF713 misregulation. Control data showed normal alleles of 5–22 repeats in 176 individuals and no additional FRA7A cases in >9,000 neurodevelopmental cytogenetic analyses. The authors noted that a firm ASD link was not yet established, but the dynamic mutation and functional dysregulation support a moderate locus-disease relationship.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 3,
-    "Citation": "pmid:25196122",
-    "Evidence detail": null,
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2014-11-01"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 4,
-    "Citation": "pmid:25196122",
-    "Evidence detail": "poorly matched but highly significant",
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2014-11-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 3,
+      "Citation": "pmid:25196122",
+      "Evidence detail": "Two unrelated ASD families were described: Family 7,792 had one male proband with a maternally derived FRA7A full CGG expansion (>450 repeats), CpG methylation, and reduced ZNF713 expression; Family TCAG0070 had three affected siblings carrying paternal FRA7A premutation alleles with partial/mosaic methylation, mitotic instability in one sibling, and ZNF713 dysregulation.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2014-11-01"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 4,
+      "Citation": "pmid:25196122",
+      "Evidence detail": "PCR sizing of 176 controls showed 14 normal alleles (5–22 CGG repeats) and no premutation-range alleles; no additional FRA7A cases were detected in >9,000 neurodevelopmental cytogenetic analyses. Controls were not phenotype-matched and the PCR assay could miss heterozygous full expansions, so support is imperfect.",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "2014-11-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [],
-  "category_summary":
-  {
+  "category_summary": {
     "Singular Evidence": 3,
     "Collective Evidence": 0,
     "Statistics": 4,
@@ -7150,8 +7154,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Genetic Evidence": 7,
     "Experimental Evidence": 0
   },


### PR DESCRIPTION
## Description

Updated the FRA7A_ZNF13 criTRia entry for **ZNF713–FRA7A** by adding a concise root-level disease/locus description and replacing incomplete evidence details with paper-supported curation text. Scores, summaries, classification, publication count, and schema were preserved. The entry remains classified as **Moderate** with total score 7. 

Fixes: #

## Major Changes

* None

## Minor Changes

* Added root-level `Description` summarizing the FRA7A CGG-repeat expansion, ASD-associated families, methylation/expression findings, control data, and uncertainty in the reported association. 
* Updated the **Probands** evidence detail from `null` to a concise summary of two unrelated ASD families with FRA7A full expansion/premutation evidence and ZNF713 dysregulation.  
* Replaced the vague **Case-control data** evidence detail with specific control findings: 176 controls with 5–22 CGG repeats, no premutation-range alleles, and no additional FRA7A cases in >9,000 neurodevelopmental cytogenetic analyses, while noting limitations.  

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
