### PR TITLE
VWA1_HMNR7 curation update

### DIFF
--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -4879,7 +4879,7 @@
   "id": "HMNR7_VWA1",
   "disease_id": "HMNR7",
   "gene": "VWA1",
-  "evidence": ["Moderate"],
+  "evidence": ["Definitive"],
   "chrom": "chr1",
   "start_hg38": 1435798,
   "stop_hg38": 1435818,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6569,58 +6569,67 @@
   "Inheritance": "AR",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/14/2025",
-  "Description": null,
+  "Description": "Biallelic VWA1 variants cause autosomal recessive hereditary motor neuropathy/neuromyopathy (HMNR7). The recurrent exon 1 10-bp repeat expansion c.62_71dup, p.(Gly25ArgfsTer74), is the predominant disease-associated allele and was reported in most families, often with loss-of-function consequences. Genetic support includes multiple unrelated affected families, trans/inheritance evidence for compound heterozygotes, and founder-haplotype/autozygosity evidence. Experimental support is mainly gene-level or patient-tissue evidence: WARP/VWA1 is an extracellular-matrix protein reported to interact with collagen VI and perlecan, and patient-derived blood or muscle tissue studies show neuromuscular biomarker/pathology changes.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:33559681",
-    "Evidence detail": "14 families",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2021-03-03"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:33559681",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2021-03-03"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:33559681",
+      "Evidence detail": "17 affected individuals from 15 unrelated families with biallelic VWA1 variants; the exon 1 10-bp repeat expansion c.62_71dup, p.(Gly25ArgfsTer74), was present in 14/15 families and homozygous in 10/15.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2021-03-03"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:33559681",
+      "Evidence detail": "Segregation support included trans confirmation for compound-heterozygous cases by allele-specific PCR, Nanopore sequencing, or parental inheritance, plus an extended consanguineous family in which a homozygous VWA1 frameshift variant lay in a shared autozygous region spanning VWA1. No formal LOD score was reported.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2021-03-03"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:38652110",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-04-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 2.0,
-    "Citation": "pmid:39502942",
-    "Evidence detail": "muscle cells of many patients",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-01-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:38652110",
+      "Evidence detail": "Gene-level evidence only: WARP/VWA1 is described as an extracellular-matrix protein expressed in muscle and peripheral nerve that interacts with collagen VI and perlecan; this paper did not perform a tandem-repeat/locus-specific interaction assay.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 2.0,
+      "Citation": "pmid:39502942",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-01-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -6629,8 +6638,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 2.5,
     "Genetic Evidence": 7.5
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6567,7 +6567,7 @@
   "Gene": "VWA1",
   "Locus_ID": "HMNR7_VWA1",
   "Inheritance": "AR",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
   "Date": "08/14/2025",
   "Description": "Biallelic VWA1 variants cause autosomal recessive hereditary motor neuropathy/neuromyopathy (HMNR7). The recurrent exon 1 10-bp repeat expansion c.62_71dup, p.(Gly25ArgfsTer74), is the predominant disease-associated allele and was reported in most families, often with loss-of-function consequences. Genetic support includes multiple unrelated affected families, trans/inheritance evidence for compound heterozygotes, and founder-haplotype/autozygosity evidence. Experimental support is mainly gene-level or patient-tissue evidence: WARP/VWA1 is an extracellular-matrix protein reported to interact with collagen VI and perlecan, and patient-derived blood or muscle tissue studies show neuromuscular biomarker/pathology changes.",
   "Source": "criTRia",
@@ -6595,6 +6595,17 @@
     "evidence_max_score": 3,
     "category_max_score": 3,
     "publication_dates": ["2021-03-03"]
+  },
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:39502942",
+    "Evidence detail": "Cohort study identifying biallelic VWA1 variants in affected individuals with consistent neuromuscular phenotype; includes clinical, neurophysiological, and biopsy data. 12 affected individuals had the c.62_71dup, an increase from 2 to 3 GGCGCGGAGC motifs. An additional  11 novel VWA1 variants were identified in the cohort. One familiy from this study overlaps with the previous pmid:33559681 cohort.",
+    "evidence_category": null,
+    "evidence_supercategory": null,
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-01-01"]
   }],
   "experimental_evidence_details": [
   {
@@ -6607,17 +6618,6 @@
     "evidence_max_score": 2,
     "category_max_score": 2,
     "publication_dates": ["2024-04-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 2.0,
-    "Citation": "pmid:39502942",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-01-01"]
   }],
   "category_summary":
   {

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6601,10 +6601,10 @@
     "Score": 6.0,
     "Citation": "pmid:39502942",
     "Evidence detail": "Cohort study identifying biallelic VWA1 variants in affected individuals with consistent neuromuscular phenotype; includes clinical, neurophysiological, and biopsy data. 12 affected individuals had the c.62_71dup, an increase from 2 to 3 GGCGCGGAGC motifs. An additional  11 novel VWA1 variants were identified in the cohort. One familiy from this study overlaps with the previous pmid:33559681 cohort.",
-    "evidence_category": null,
-    "evidence_supercategory": null,
-    "evidence_max_score": 2,
-    "category_max_score": 2,
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
     "publication_dates": ["2024-01-01"]
   }],
   "experimental_evidence_details": [
@@ -6621,23 +6621,23 @@
   }],
   "category_summary":
   {
-    "Singular Evidence": 6.0,
+    "Singular Evidence": 6,
     "Collective Evidence": 1.5,
     "Statistics": 0,
     "Function": 0.5,
-    "Functional Alteration": 2.0,
+    "Functional Alteration": 0,
     "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 2.5,
-    "Genetic Evidence": 7.5
+    "Experimental Evidence": 0.5,
+    "Genetic Evidence": 12
   },
-  "total_score": 10.0,
+  "total_score": 12.5,
   "publication_count": 3,
   "publication_interval_years": 3.08,
-  "classification": "Moderate"
+  "classification": "Definitive"
 },
 {
   "Disease_ID": "DBQD2",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6574,62 +6574,53 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:33559681",
-      "Evidence detail": "17 affected individuals from 15 unrelated families with biallelic VWA1 variants; the exon 1 10-bp repeat expansion c.62_71dup, p.(Gly25ArgfsTer74), was present in 14/15 families and homozygous in 10/15.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2021-03-03"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:33559681",
-      "Evidence detail": "Segregation support included trans confirmation for compound-heterozygous cases by allele-specific PCR, Nanopore sequencing, or parental inheritance, plus an extended consanguineous family in which a homozygous VWA1 frameshift variant lay in a shared autozygous region spanning VWA1. No formal LOD score was reported.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2021-03-03"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:33559681",
+    "Evidence detail": "17 affected individuals from 15 unrelated families with biallelic VWA1 variants; the exon 1 10-bp repeat expansion c.62_71dup, p.(Gly25ArgfsTer74), was present in 14/15 families and homozygous in 10/15.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2021-03-03"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:33559681",
+    "Evidence detail": "Segregation support included trans confirmation for compound-heterozygous cases by allele-specific PCR, Nanopore sequencing, or parental inheritance, plus an extended consanguineous family in which a homozygous VWA1 frameshift variant lay in a shared autozygous region spanning VWA1. No formal LOD score was reported.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2021-03-03"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:38652110",
-      "Evidence detail": "Gene-level evidence only: WARP/VWA1 is described as an extracellular-matrix protein expressed in muscle and peripheral nerve that interacts with collagen VI and perlecan; this paper did not perform a tandem-repeat/locus-specific interaction assay.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 2.0,
-      "Citation": "pmid:39502942",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-01-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:38652110",
+    "Evidence detail": "Gene-level evidence only: WARP/VWA1 is described as an extracellular-matrix protein expressed in muscle and peripheral nerve that interacts with collagen VI and perlecan; this paper did not perform a tandem-repeat/locus-specific interaction assay.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-04-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 2.0,
+    "Citation": "pmid:39502942",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-01-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -6638,7 +6629,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 2.5,
     "Genetic Evidence": 7.5
   },


### PR DESCRIPTION
## Description

Updated the `VWA1_HMNR7` criTRia curation evidence details and description based on reviewed source papers.

Fixes: #

## Major Changes

* None

## Minor Changes

* Updated root-level `Description` for `VWA1_HMNR7`.
* Expanded vague/null evidence details for:

  * `Probands` — clarified 17 affected individuals from 15 unrelated families and recurrent c.62_71dup/p.Gly25ArgfsTer74 allele.
  * `Segregation` — clarified trans confirmation, inheritance evidence, and autozygosity support; noted no formal LOD score was reported.
  * `Protein interaction` — clarified this is gene-level evidence only and not tandem-repeat/locus-specific.
* Left `Patient cells` evidence detail blank/pending curator review because PMID:39502942 does not clearly support a patient-derived cell functional assay tied to the VWA1 repeat locus.
https://github.com/dashnowlab/STRchive/issues/403
* No scores, category summaries, total score, classification, publication counts, or schema fields were changed.

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
