### PR TITLE
ZIC2-HPE5-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6488,6 +6488,12 @@
     "publication_dates": ["2005-02-01"]
   },
   {
+    "Evidence type": "Non-patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:42033229",
+    "Evidence detail": "In non‑patient cell models, genome‑edited mouse embryonic stem cells differentiated toward neural progenitors showed that ZIC2 directly regulates neural patterning genes by binding and activating distal enhancers. Loss of ZIC2 disrupted chromatin accessibility and WNT‑related regulatory programs, demonstrating a cell‑autonomous regulatory role for ZIC2 during early neural differentiation.",
+  },
+  {
     "Evidence type": "Non-human model organism",
     "Score": 2.0,
     "Citation": "pmid:10677508",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6442,101 +6442,86 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:11285244",
-      "Evidence detail": "Screened 509 unrelated HPE patients with normal chromosomes; 16 affected individuals from 15 unrelated families had ZIC2 mutations. Seven mutations were frameshift/null alleles, and a recurrent C-terminal alanine-tract expansion occurred in seven patients from six families, including de novo and paternal mosaic cases.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2001-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Computational",
-      "Score": 1.0,
-      "Citation": "pmid:19177455",
-      "Evidence detail": "Compilation of 83 HPE-specific ZIC2 variants absent from controls showed recurrent predicted loss-of-function, including frequent frameshift/truncating variants (>55%), zinc-finger missense clustering at conserved DNA-binding residues, and COOH-terminal/polyalanine variants predicted or shown to impair ZIC2 function.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2009-04-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:11285244",
+    "Evidence detail": "Screened 509 unrelated HPE patients with normal chromosomes; 16 affected individuals from 15 unrelated families had ZIC2 mutations. Seven mutations were frameshift/null alleles, and a recurrent C-terminal alanine-tract expansion occurred in seven patients from six families, including de novo and paternal mosaic cases.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2001-04-01"]
+  },
+  {
+    "Evidence type": "Computational",
+    "Score": 1.0,
+    "Citation": "pmid:19177455",
+    "Evidence detail": "Compilation of 83 HPE-specific ZIC2 variants absent from controls showed recurrent predicted loss-of-function, including frequent frameshift/truncating variants (>55%), zinc-finger missense clustering at conserved DNA-binding residues, and COOH-terminal/polyalanine variants predicted or shown to impair ZIC2 function.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2009-04-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:15590697",
-      "Evidence detail": "In vitro ZIC2 reporter assays showed that HPE-associated mutations altered transcriptional activation; the naturally occurring 25-alanine expansion reduced apoE promoter transactivation to ~5% of wild-type activity.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2005-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:15590697",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2005-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:15590697",
-      "Evidence detail": "C-terminal deletion/truncation and alanine-tract length changes altered ZIC2-mediated transcriptional activation in a promoter-specific manner; the C-terminal contains activation/repression domains and the alanine tract modulates DNA binding.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2005-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:15590697",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2005-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:15590697",
-      "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: PMID 15590697 discusses Zic2 mouse mutations with forebrain defects and mimics a murine C370S mutation in vitro; no new in vivo model of the alanine-tract expansion was generated.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2005-02-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:15590697",
+    "Evidence detail": "In vitro ZIC2 reporter assays showed that HPE-associated mutations altered transcriptional activation; the naturally occurring 25-alanine expansion reduced apoE promoter transactivation to ~5% of wild-type activity.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2005-02-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:15590697",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2005-02-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:15590697",
+    "Evidence detail": "C-terminal deletion/truncation and alanine-tract length changes altered ZIC2-mediated transcriptional activation in a promoter-specific manner; the C-terminal contains activation/repression domains and the alanine tract modulates DNA binding.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2005-02-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:15590697",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2005-02-01"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:15590697",
+    "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: PMID 15590697 discusses Zic2 mouse mutations with forebrain defects and mimics a murine C370S mutation in vitro; no new in vivo model of the alanine-tract expansion was generated.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2005-02-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 0,
@@ -6545,7 +6530,8 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 4.5,
     "Genetic Evidence": 7.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6437,91 +6437,106 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "03/02/2026",
-  "Description": null,
+  "Description": "Heterozygous ZIC2 variants, including a recurrent C-terminal polyalanine tract expansion from 15 to 25 alanines, are associated with autosomal dominant holoprosencephaly 5 (HPE5). Reported genetic evidence includes ZIC2 mutations in 16 affected individuals from 15 unrelated HPE families, with frameshift/null alleles, an in-frame deletion, a missense variant, and alanine-tract expansions including de novo and paternal mosaic cases. Functional studies support a dosage-sensitive transcription factor mechanism, with HPE-associated ZIC2 mutations altering DNA binding and ZIC2-mediated transcriptional activation.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:11285244",
-    "Evidence detail": "15 + de novo | probands:15",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2001-04-01"]
-  },
-  {
-    "Evidence type": "Computational",
-    "Score": 1.0,
-    "Citation": "pmid:19177455",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2009-04-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:11285244",
+      "Evidence detail": "Screened 509 unrelated HPE patients with normal chromosomes; 16 affected individuals from 15 unrelated families had ZIC2 mutations. Seven mutations were frameshift/null alleles, and a recurrent C-terminal alanine-tract expansion occurred in seven patients from six families, including de novo and paternal mosaic cases.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2001-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Computational",
+      "Score": 1.0,
+      "Citation": "pmid:19177455",
+      "Evidence detail": "Compilation of 83 HPE-specific ZIC2 variants absent from controls showed recurrent predicted loss-of-function, including frequent frameshift/truncating variants (>55%), zinc-finger missense clustering at conserved DNA-binding residues, and COOH-terminal/polyalanine variants predicted or shown to impair ZIC2 function.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2009-04-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "transc",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2005-02-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:15590697",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2005-02-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "C term",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2005-02-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "patient mutations",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2005-02-01"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "mouse | mouse, from patient mutations, evaluated C terminal, protein, transcription, etc",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2005-02-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:15590697",
+      "Evidence detail": "In vitro ZIC2 reporter assays showed that HPE-associated mutations altered transcriptional activation; the naturally occurring 25-alanine expansion reduced apoE promoter transactivation to ~5% of wild-type activity.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2005-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:15590697",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2005-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:15590697",
+      "Evidence detail": "C-terminal deletion/truncation and alanine-tract length changes altered ZIC2-mediated transcriptional activation in a promoter-specific manner; the C-terminal contains activation/repression domains and the alanine tract modulates DNA binding.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2005-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:15590697",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2005-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:15590697",
+      "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: PMID 15590697 discusses Zic2 mouse mutations with forebrain defects and mimics a murine C370S mutation in vitro; no new in vivo model of the alanine-tract expansion was generated.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2005-02-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 0,
@@ -6530,8 +6545,7 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 4.5,
     "Genetic Evidence": 7.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6436,7 +6436,7 @@
   "Locus_ID": "HPE5_ZIC2",
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
-  "Date": "03/02/2026",
+  "Date": "05/24/2026",
   "Description": "Heterozygous ZIC2 variants, including a recurrent C-terminal polyalanine tract expansion from 15 to 25 alanines, are associated with autosomal dominant holoprosencephaly 5 (HPE5). Reported genetic evidence includes ZIC2 mutations in 16 affected individuals from 15 unrelated HPE families, with frameshift/null alleles, an in-frame deletion, a missense variant, and alanine-tract expansions including de novo and paternal mosaic cases. Functional studies support a dosage-sensitive transcription factor mechanism, with HPE-associated ZIC2 mutations altering DNA binding and ZIC2-mediated transcriptional activation.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
@@ -6449,8 +6449,8 @@
     "Evidence detail": "Screened 509 unrelated HPE patients with normal chromosomes; 16 affected individuals from 15 unrelated families had ZIC2 mutations. Seven mutations were frameshift/null alleles, and a recurrent C-terminal alanine-tract expansion occurred in seven patients from six families, including de novo and paternal mosaic cases.",
     "evidence_category": "Singular Evidence",
     "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
+    "evidence_max_score": 6.0,
+    "category_max_score": 6.0,
     "publication_dates": ["2001-04-01"]
   },
   {
@@ -6460,8 +6460,8 @@
     "Evidence detail": "Compilation of 83 HPE-specific ZIC2 variants absent from controls showed recurrent predicted loss-of-function, including frequent frameshift/truncating variants (>55%), zinc-finger missense clustering at conserved DNA-binding residues, and COOH-terminal/polyalanine variants predicted or shown to impair ZIC2 function.",
     "evidence_category": "Collective Evidence",
     "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
+    "evidence_max_score": 3.0,
+    "category_max_score": 3.0,
     "publication_dates": ["2009-04-01"]
   }],
   "experimental_evidence_details": [
@@ -6472,9 +6472,20 @@
     "Evidence detail": "In vitro ZIC2 reporter assays showed that HPE-associated mutations altered transcriptional activation; the naturally occurring 25-alanine expansion reduced apoE promoter transactivation to ~5% of wild-type activity.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
+    "evidence_max_score": 2.0,
+    "category_max_score": 2.0,
     "publication_dates": ["2005-02-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:29391420",
+    "Evidence detail": "ChIP, in vitro DNA‑binding, and reporter assays showed that ZIC2 directly binds cis‑regulatory elements upstream of TGIF1 (another HPE gene) and activates its transcription, with higher affinity than GLI proteins. This identifies TGIF1 as a direct downstream target of ZIC2, linking ZIC2‑mediated transcriptional regulation to forebrain development and HPE.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2.0,
+    "category_max_score": 2.0,
+    "publication_dates": ["2018-02-01"]
   },
   {
     "Evidence type": "Regulatory impact",
@@ -6483,8 +6494,8 @@
     "Evidence detail": "C-terminal deletion/truncation and alanine-tract length changes altered ZIC2-mediated transcriptional activation in a promoter-specific manner; the C-terminal contains activation/repression domains and the alanine tract modulates DNA binding.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
+    "evidence_max_score": 2.0,
+    "category_max_score": 2.0,
     "publication_dates": ["2005-02-01"]
   },
   {
@@ -6492,6 +6503,11 @@
     "Score": 1.0,
     "Citation": "pmid:42033229",
     "Evidence detail": "In non‑patient cell models, genome‑edited mouse embryonic stem cells differentiated toward neural progenitors showed that ZIC2 directly regulates neural patterning genes by binding and activating distal enhancers. Loss of ZIC2 disrupted chromatin accessibility and WNT‑related regulatory programs, demonstrating a cell‑autonomous regulatory role for ZIC2 during early neural differentiation.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1.0,
+    "category_max_score": 2.0,
+    "publication_dates": ["2026-04-23"]
   },
   {
     "Evidence type": "Non-human model organism",
@@ -6500,28 +6516,39 @@
     "Evidence detail": "Gene-level evidence: A mouse model with reduced Zic2 expression shows delayed neurulation, leading to holoprosencephaly and spina bifida, along with impaired roof plate and neural crest development. These findings demonstrate that proper Zic2 dosage is critical for early neural tube patterning and timing, providing a mechanistic link to human HPE.",
     "evidence_category": "Models",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2005-02-01"]
+    "evidence_max_score": 4.0,
+    "category_max_score": 4.0,
+    "publication_dates": ["2000-02-15"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:18617531",
+    "Evidence detail": "The study used homozygous Zic2^Ku missense mutant mice, which lack ZIC2 DNA‑binding and transcriptional activity, and showed that Zic2 loss causes holoprosencephaly through an early organizer defect during mid‑gastrulation. This leads to impaired prechordal plate development and forebrain midline defects independent of Sonic hedgehog signaling.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4.0,
+    "category_max_score": 4.0,
+    "publication_dates": ["2008-10-01"]
   }],
   "category_summary":
   {
     "Singular Evidence": 6.0,
-    "Collective Evidence": 1.0,
+    "Collective Evidence": 0.5,
     "Statistics": 0,
     "Function": 1.5,
     "Functional Alteration": 1.0,
-    "Models": 2.0,
+    "Models": 4.0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 4.5,
-    "Genetic Evidence": 7.0
+    "Experimental Evidence": 6,
+    "Genetic Evidence": 6.5
   },
-  "total_score": 11.5,
-  "publication_count": 3,
-  "publication_interval_years": 8.0,
+  "total_score": 12.5,
+  "publication_count": 7,
+  "publication_interval_years": 26.18,
   "classification": "Definitive"
 },
 {

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6435,7 +6435,7 @@
   "Gene": "ZIC2",
   "Locus_ID": "HPE5_ZIC2",
   "Inheritance": "AD",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
   "Date": "03/02/2026",
   "Description": "Heterozygous ZIC2 variants, including a recurrent C-terminal polyalanine tract expansion from 15 to 25 alanines, are associated with autosomal dominant holoprosencephaly 5 (HPE5). Reported genetic evidence includes ZIC2 mutations in 16 affected individuals from 15 unrelated HPE families, with frameshift/null alleles, an in-frame deletion, a missense variant, and alanine-tract expansions including de novo and paternal mosaic cases. Functional studies support a dosage-sensitive transcription factor mechanism, with HPE-associated ZIC2 mutations altering DNA binding and ZIC2-mediated transcriptional activation.",
   "Source": "criTRia",
@@ -6455,7 +6455,7 @@
   },
   {
     "Evidence type": "Computational",
-    "Score": 1.0,
+    "Score": 0.5,
     "Citation": "pmid:19177455",
     "Evidence detail": "Compilation of 83 HPE-specific ZIC2 variants absent from controls showed recurrent predicted loss-of-function, including frequent frameshift/truncating variants (>55%), zinc-finger missense clustering at conserved DNA-binding residues, and COOH-terminal/polyalanine variants predicted or shown to impair ZIC2 function.",
     "evidence_category": "Collective Evidence",
@@ -6477,17 +6477,6 @@
     "publication_dates": ["2005-02-01"]
   },
   {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2005-02-01"]
-  },
-  {
     "Evidence type": "Regulatory impact",
     "Score": 0.5,
     "Citation": "pmid:15590697",
@@ -6499,21 +6488,10 @@
     "publication_dates": ["2005-02-01"]
   },
   {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2005-02-01"]
-  },
-  {
     "Evidence type": "Non-human model organism",
     "Score": 2.0,
-    "Citation": "pmid:15590697",
-    "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: PMID 15590697 discusses Zic2 mouse mutations with forebrain defects and mimics a murine C370S mutation in vitro; no new in vivo model of the alanine-tract expansion was generated.",
+    "Citation": "pmid:10677508",
+    "Evidence detail": "Gene-level evidence: A mouse model with reduced Zic2 expression shows delayed neurulation, leading to holoprosencephaly and spina bifida, along with impaired roof plate and neural crest development. These findings demonstrate that proper Zic2 dosage is critical for early neural tube patterning and timing, providing a mechanistic link to human HPE.",
     "evidence_category": "Models",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,


### PR DESCRIPTION
## Description

Updated the ZIC2/HPE5 criTRia curation JSON to improve incomplete or vague evidence details and add a root-level disease/locus description.

## Major Changes

* Added a root-level `Description` for the ZIC2/HPE5 locus-disease relationship.
* Updated evidence-detail text for ZIC2/HPE5 using the supporting PMID-specific papers.
* Clarified that ZIC2/HPE5 evidence includes recurrent C-terminal polyalanine tract expansion from 15 to 25 alanines, alongside other ZIC2 loss-of-function variants.
* Added curator-review flags for evidence rows where the cited paper does not clearly support the assigned criTRia category.

## Minor Changes

* Improved wording for existing evidence rows without changing scores or evidence structure.
* Expanded vague entries such as `transc`, `C term`, and `mouse` into concise evidence descriptions.
* Left unsupported/unclear rows blank or flagged for curator review, including:
https://github.com/dashnowlab/STRchive/issues/405
  * `Protein interaction`
  * `Patient cells`
  * potential review of `Non-human model organism` as gene-level rather than tandem-repeat/locus-specific evidence.

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If breaking change, increment X.
* [ ] Ask someone to review this PR
