### PR TITLE
PABPN1_OPMD criTRia curation update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4083,124 +4083,133 @@
   "Inheritance": "AD/AR",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/14/2025",
-  "Description": null,
+  "Description": "Oculopharyngeal muscular dystrophy (OPMD) is an adult-onset myopathy characterized by ptosis, dysphagia, and proximal limb weakness. The curated locus is the short GCN/GCG repeat in exon 1 of PABPN1 (formerly PABP2), where expansions enlarge the N-terminal polyalanine tract and are associated with autosomal dominant and recessive OPMD. Uploaded genetic evidence supports pathogenic repeat expansions through large clinically characterized cohorts, founder/segregation haplotype data, and genotype–phenotype correlations including expansion-size and gene-dose effects.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:35112761",
-    "Evidence detail": null,
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2022-05-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 2.0,
-    "Citation": "pmid:28011929; pmid:9392020",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2017-01-24", "1997-10-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:11087766",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2000-11-14"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 6.0,
-    "Citation": "pmid:28011929",
-    "Evidence detail": null,
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2017-01-24"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 0.0,
-    "Citation": "pmid:37090934; pmid:37371433",
-    "Evidence detail": "Disputed with pmid:37371433 evidence saying no relationship",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2023-04-01", "2023-06-15"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:35112761",
+      "Evidence detail": "Canary Islands cohort of 123 genetically diagnosed OPMD patients; 113/120 analyzed patients (94.2%) carried a heterozygous PABPN1 (GCN)15 expanded allele, with typical OPMD features including ptosis, dysphagia, and later proximal weakness.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2022-05-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 2.0,
+      "Citation": "pmid:28011929; pmid:9392020",
+      "Evidence detail": "PMID 28011929: French cohort of 354 unrelated index cases showed pathogenic PABPN1 (GCN)11–17 alleles and a correlation between expansion size and age at diagnosis/severity, with homozygous patients more severely affected. PMID 9392020: linkage study supports the chromosome 14 OPMD locus but is gene/locus-mapping evidence, not repeat allele size-specific.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2017-01-24",
+        "1997-10-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:11087766",
+      "Evidence detail": "In 23 Bukhara Jewish patients from 8 unrelated families, all carried the PABP2/PABPN1 (GCG)9 mutation and shared a four-marker haplotype, supporting segregation of a shared founder mutation in this population.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2000-11-14"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 6.0,
+      "Citation": "pmid:28011929",
+      "Evidence detail": "French diagnostic cohort of 354 unrelated PABPN1 expansion-positive index cases characterized pathogenic (GCN)11–17 alleles; 200 control chromosomes had no (GCN)11 allele, supporting enrichment/rarity of expanded alleles in affected individuals versus controls.",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "2017-01-24"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:9462747",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:9462747",
+      "Evidence detail": "Gene-level, not repeat-locus-specific: PABP2/PABPN1 is a nuclear poly(A)-binding protein involved in mRNA polyadenylation; the paper proposed that expanded polyalanine PABP2 may accumulate as nuclear filament inclusions.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1998-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:9462747",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1998-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:9462747",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1998-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:9462747",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1998-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:9462747",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1998-02-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 6.0,
@@ -4209,8 +4218,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 12
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4088,128 +4088,108 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:35112761",
-      "Evidence detail": "Canary Islands cohort of 123 genetically diagnosed OPMD patients; 113/120 analyzed patients (94.2%) carried a heterozygous PABPN1 (GCN)15 expanded allele, with typical OPMD features including ptosis, dysphagia, and later proximal weakness.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2022-05-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 2.0,
-      "Citation": "pmid:28011929; pmid:9392020",
-      "Evidence detail": "PMID 28011929: French cohort of 354 unrelated index cases showed pathogenic PABPN1 (GCN)11–17 alleles and a correlation between expansion size and age at diagnosis/severity, with homozygous patients more severely affected. PMID 9392020: linkage study supports the chromosome 14 OPMD locus but is gene/locus-mapping evidence, not repeat allele size-specific.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2017-01-24",
-        "1997-10-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:11087766",
-      "Evidence detail": "In 23 Bukhara Jewish patients from 8 unrelated families, all carried the PABP2/PABPN1 (GCG)9 mutation and shared a four-marker haplotype, supporting segregation of a shared founder mutation in this population.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2000-11-14"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 6.0,
-      "Citation": "pmid:28011929",
-      "Evidence detail": "French diagnostic cohort of 354 unrelated PABPN1 expansion-positive index cases characterized pathogenic (GCN)11–17 alleles; 200 control chromosomes had no (GCN)11 allele, supporting enrichment/rarity of expanded alleles in affected individuals versus controls.",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "2017-01-24"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:35112761",
+    "Evidence detail": "Canary Islands cohort of 123 genetically diagnosed OPMD patients; 113/120 analyzed patients (94.2%) carried a heterozygous PABPN1 (GCN)15 expanded allele, with typical OPMD features including ptosis, dysphagia, and later proximal weakness.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2022-05-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 2.0,
+    "Citation": "pmid:28011929; pmid:9392020",
+    "Evidence detail": "PMID 28011929: French cohort of 354 unrelated index cases showed pathogenic PABPN1 (GCN)11–17 alleles and a correlation between expansion size and age at diagnosis/severity, with homozygous patients more severely affected. PMID 9392020: linkage study supports the chromosome 14 OPMD locus but is gene/locus-mapping evidence, not repeat allele size-specific.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2017-01-24", "1997-10-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:11087766",
+    "Evidence detail": "In 23 Bukhara Jewish patients from 8 unrelated families, all carried the PABP2/PABPN1 (GCG)9 mutation and shared a four-marker haplotype, supporting segregation of a shared founder mutation in this population.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2000-11-14"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 6.0,
+    "Citation": "pmid:28011929",
+    "Evidence detail": "French diagnostic cohort of 354 unrelated PABPN1 expansion-positive index cases characterized pathogenic (GCN)11–17 alleles; 200 control chromosomes had no (GCN)11 allele, supporting enrichment/rarity of expanded alleles in affected individuals versus controls.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2017-01-24"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:9462747",
-      "Evidence detail": "Gene-level, not repeat-locus-specific: PABP2/PABPN1 is a nuclear poly(A)-binding protein involved in mRNA polyadenylation; the paper proposed that expanded polyalanine PABP2 may accumulate as nuclear filament inclusions.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1998-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:9462747",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1998-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:9462747",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1998-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:9462747",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1998-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:9462747",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1998-02-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:9462747",
+    "Evidence detail": "Gene-level, not repeat-locus-specific: PABP2/PABPN1 is a nuclear poly(A)-binding protein involved in mRNA polyadenylation; the paper proposed that expanded polyalanine PABP2 may accumulate as nuclear filament inclusions.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1998-02-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:9462747",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1998-02-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:9462747",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1998-02-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:9462747",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1998-02-01"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:9462747",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_dates": ["1998-02-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 6.0,
@@ -4218,13 +4198,14 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 12
   },
   "total_score": 15.0,
-  "publication_count": 7,
-  "publication_interval_years": 25.7,
+  "publication_count": 5,
+  "publication_interval_years": 24.58,
   "classification": "Definitive"
 },
 {

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4095,8 +4095,8 @@
     "Evidence detail": "Canary Islands cohort of 123 genetically diagnosed OPMD patients; 113/120 analyzed patients (94.2%) carried a heterozygous PABPN1 (GCN)15 expanded allele, with typical OPMD features including ptosis, dysphagia, and later proximal weakness.",
     "evidence_category": "Singular Evidence",
     "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
+    "evidence_max_score": 6.0,
+    "category_max_score": 6.0,
     "publication_dates": ["2022-05-01"]
   },
   {
@@ -4106,8 +4106,8 @@
     "Evidence detail": "PMID 28011929: French cohort of 354 unrelated index cases showed pathogenic PABPN1 (GCN)11–17 alleles and a correlation between expansion size and age at diagnosis/severity, with homozygous patients more severely affected. PMID 9392020: linkage study supports the chromosome 14 OPMD locus but is gene/locus-mapping evidence, not repeat allele size-specific.",
     "evidence_category": "Collective Evidence",
     "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
+    "evidence_max_score": 2.0,
+    "category_max_score": 3.0,
     "publication_dates": ["2017-01-24", "1997-10-01"]
   },
   {
@@ -4117,9 +4117,20 @@
     "Evidence detail": "In 23 Bukhara Jewish patients from 8 unrelated families, all carried the PABP2/PABPN1 (GCG)9 mutation and shared a four-marker haplotype, supporting segregation of a shared founder mutation in this population.",
     "evidence_category": "Collective Evidence",
     "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
+    "evidence_max_score": 3.0,
+    "category_max_score": 3.0,
     "publication_dates": ["2000-11-14"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:9392020",
+    "Evidence detail": "Linkage analysis in 11 large French Canadian families with OPMD identified a 1.5cM region around D14S990 that includes PABPN1 (LOD = 26.05).",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3.0,
+    "category_max_score": 3.0,
+    "publication_dates": ["1997-10-01"]
   },
   {
     "Evidence type": "Case-control data",
@@ -4128,8 +4139,8 @@
     "Evidence detail": "French diagnostic cohort of 354 unrelated PABPN1 expansion-positive index cases characterized pathogenic (GCN)11–17 alleles; 200 control chromosomes had no (GCN)11 allele, supporting enrichment/rarity of expanded alleles in affected individuals versus controls.",
     "evidence_category": "Statistics",
     "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
+    "evidence_max_score": 12.0,
+    "category_max_score": 12.0,
     "publication_dates": ["2017-01-24"]
   }],
   "experimental_evidence_details": [
@@ -4137,55 +4148,11 @@
     "Evidence type": "Biochemical function",
     "Score": 0.5,
     "Citation": "pmid:9462747",
-    "Evidence detail": "Gene-level, not repeat-locus-specific: PABP2/PABPN1 is a nuclear poly(A)-binding protein involved in mRNA polyadenylation; the paper proposed that expanded polyalanine PABP2 may accumulate as nuclear filament inclusions.",
+    "Evidence detail": "Gene-level, not repeat-locus-specific: PABP2 (now known as PABPN1) is a nuclear poly(A)-binding protein involved in mRNA polyadenylation; the paper proposed that expanded polyalanine PABP2 may accumulate as nuclear filament inclusions.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:9462747",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1998-02-01"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:9462747",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
+    "evidence_max_score": 2.0,
+    "category_max_score": 2.0,
     "publication_dates": ["1998-02-01"]
   }],
   "category_summary":
@@ -4193,17 +4160,17 @@
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 6.0,
-    "Function": 1.5,
-    "Functional Alteration": 1.5,
+    "Function": 0.5,
+    "Functional Alteration": 0,
     "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 3.0,
+    "Experimental Evidence": 0.5,
     "Genetic Evidence": 12
   },
-  "total_score": 15.0,
+  "total_score": 12.5,
   "publication_count": 5,
   "publication_interval_years": 24.58,
   "classification": "Definitive"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4081,7 +4081,7 @@
   "Gene": "PABPN1",
   "Locus_ID": "OPMD_PABPN1",
   "Inheritance": "AD/AR",
-  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Curator": "Macayla Weiner, Laurel Hiatt, Harriet Dashnow",
   "Date": "08/14/2025",
   "Description": "Oculopharyngeal muscular dystrophy (OPMD) is an adult-onset myopathy characterized by ptosis, dysphagia, and proximal limb weakness. The curated locus is the short GCN/GCG repeat in exon 1 of PABPN1 (formerly PABP2), where expansions enlarge the N-terminal polyalanine tract and are associated with autosomal dominant and recessive OPMD. Uploaded genetic evidence supports pathogenic repeat expansions through large clinically characterized cohorts, founder/segregation haplotype data, and genotype–phenotype correlations including expansion-size and gene-dose effects.",
   "Source": "criTRia",


### PR DESCRIPTION
## Description

Updated the **PABPN1_OPMD** criTRia curation by filling the root-level `Description` and adding concise evidence details for supported genetic evidence rows. Experimental rows linked to **PMID:9462747** were left for curator follow-up where direct repeat-specific functional assay support was unclear.

Fixes: # **add curator-review issue number here**

## Major Changes

* None

## Minor Changes

* Added root-level `Description` for **PABPN1_OPMD**
* Added evidence details for:

  * Probands
  * Allele
  * Segregation
  * Case-control data
  * Biochemical function
* Left unsupported/uncertain experimental evidence rows blank for curator review:
https://github.com/dashnowlab/STRchive/issues/417
  * Protein interaction
  * Regulatory impact
  * Patient cells
  * Non-patient cells

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
