### PR TITLE
NUTM2B-AS1_OPML1-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4036,7 +4036,7 @@
   },
   {
     "Evidence type": "Regulatory impact",
-    "Score": 0,
+    "Score": 0.0,
     "Citation": "pmid:38159879",
     "Evidence detail": "Study reports minimal methylation near the LOC642361/NUTM2B-AS1 CGG repeat region, no significant methylation difference between patients and healthy controls, and no significant LOC642361/NUTM2B-AS1 expression difference by RT-qPCR between patients, asymptomatic carriers, and controls. This evidence was not scored, however noted here for completeness.",
     "evidence_category": "Function",
@@ -4061,17 +4061,17 @@
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 0,
-    "Function": 1.5,
+    "Function": 1.0,
     "Functional Alteration": 1.0,
     "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 2.5,
+    "Experimental Evidence": 2.0,
     "Genetic Evidence": 7.5
   },
-  "total_score": 10.0,
+  "total_score": 9.5,
   "publication_count": 4,
   "publication_interval_years": 5.0,
   "classification": "Moderate"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3989,90 +3989,75 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:31332380; pmid:37923380; pmid:39308795",
-      "Evidence detail": "PMID 31332380: one OPML family (F5305) with CGG/CCG expansion in LOC642361/NUTM2B-AS1; PMID 37923380: two unrelated Chinese OPDM cases with expansions >70 repeats among 26 unsolved OPDM cases; PMID 39308795: four Thai OPDM patients from three unrelated families with expansions >100 repeats/strong somatic instability.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2019-08-01",
-        "2024-03-21",
-        "2024-08-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:31332380",
-      "Evidence detail": "PMID 31332380: In family F5305, RP-PCR confirmed the expansion in four affected individuals and absence in seven unaffected relatives, including three married-in controls; the expansion was absent in 1,000 controls.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2019-08-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:31332380; pmid:37923380; pmid:39308795",
+    "Evidence detail": "PMID 31332380: one OPML family (F5305) with CGG/CCG expansion in LOC642361/NUTM2B-AS1; PMID 37923380: two unrelated Chinese OPDM cases with expansions >70 repeats among 26 unsolved OPDM cases; PMID 39308795: four Thai OPDM patients from three unrelated families with expansions >100 repeats/strong somatic instability.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2019-08-01", "2024-03-21", "2024-08-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:31332380",
+    "Evidence detail": "PMID 31332380: In family F5305, RP-PCR confirmed the expansion in four affected individuals and absence in seven unaffected relatives, including three married-in controls; the expansion was absent in 1,000 controls.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2019-08-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:38159879",
-      "Evidence detail": "PMID 38159879: Patient muscle immunofluorescence showed aggrephagy pathway proteins p62, NBR1, and LC3B accumulated in intranuclear inclusions, suggesting the LOC642361/NUTM2B-AS1 CGG expansion may impair aggrephagic capacity.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:38159879",
-      "Evidence detail": "PMID 38159879: Patient muscle immunofluorescence showed RNA-binding proteins hnRNPA1, hnRNPA2B1, and MBNL1 accumulated in intranuclear inclusions, consistent with repeat-associated RNA-binding protein sequestration.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:38159879",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:38159879",
-      "Evidence detail": "PMID 38159879: Patient muscle biopsies showed myopathic changes with rimmed vacuoles, p62-positive intranuclear inclusions, filamentous aggregates by electron microscopy, autophagic vacuoles, and swollen/disordered mitochondria.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-02-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:38159879",
+    "Evidence detail": "PMID 38159879: Patient muscle immunofluorescence showed aggrephagy pathway proteins p62, NBR1, and LC3B accumulated in intranuclear inclusions, suggesting the LOC642361/NUTM2B-AS1 CGG expansion may impair aggrephagic capacity.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-02-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:38159879",
+    "Evidence detail": "PMID 38159879: Patient muscle immunofluorescence showed RNA-binding proteins hnRNPA1, hnRNPA2B1, and MBNL1 accumulated in intranuclear inclusions, consistent with repeat-associated RNA-binding protein sequestration.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-02-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:38159879",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-02-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:38159879",
+    "Evidence detail": "PMID 38159879: Patient muscle biopsies showed myopathic changes with rimmed vacuoles, p62-positive intranuclear inclusions, filamentous aggregates by electron microscopy, autophagic vacuoles, and swollen/disordered mitochondria.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-02-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -4081,7 +4066,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 2.5,
     "Genetic Evidence": 7.5
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4036,9 +4036,9 @@
   },
   {
     "Evidence type": "Regulatory impact",
-    "Score": 0.5,
+    "Score": 0,
     "Citation": "pmid:38159879",
-    "Evidence detail": "",
+    "Evidence detail": "Study reports minimal methylation near the LOC642361/NUTM2B-AS1 CGG repeat region, no significant methylation difference between patients and healthy controls, and no significant LOC642361/NUTM2B-AS1 expression difference by RT-qPCR between patients, asymptomatic carriers, and controls. This evidence was not scored, however noted here for completeness.",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3984,80 +3984,95 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "A heterozygous CGG/CCG repeat expansion in overlapping noncoding exons of bidirectionally transcribed LOC642361/NUTM2B-AS1 is associated with autosomal dominant OPML1/LOC642361-NUTM2B-AS1-related oculopharyngeal myopathy spectrum. The original report identified the expansion in one Japanese OPML family with leukoencephalopathy, with segregation in affected relatives and absence in unaffected relatives and 1,000 controls. Subsequent independent reports identified OPDM-predominant cases from Chinese and Thai families, expanding the phenotype and showing variable or absent leukoencephalopathy. Patient-muscle studies showed rimmed vacuoles, p62-positive intranuclear inclusions, aggrephagy/RNA-binding protein accumulation, and mitochondrial abnormalities, supporting a repeat-mediated pathogenic mechanism.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:31332380; pmid:37923380; pmid:39308795",
-    "Evidence detail": "1, 3, 3",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2019-08-01", "2024-03-21", "2024-08-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:31332380",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2019-08-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:31332380; pmid:37923380; pmid:39308795",
+      "Evidence detail": "PMID 31332380: one OPML family (F5305) with CGG/CCG expansion in LOC642361/NUTM2B-AS1; PMID 37923380: two unrelated Chinese OPDM cases with expansions >70 repeats among 26 unsolved OPDM cases; PMID 39308795: four Thai OPDM patients from three unrelated families with expansions >100 repeats/strong somatic instability.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2019-08-01",
+        "2024-03-21",
+        "2024-08-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:31332380",
+      "Evidence detail": "PMID 31332380: In family F5305, RP-PCR confirmed the expansion in four affected individuals and absence in seven unaffected relatives, including three married-in controls; the expansion was absent in 1,000 controls.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2019-08-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:38159879",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-02-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:38159879",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-02-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:38159879",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-02-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:38159879",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-02-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:38159879",
+      "Evidence detail": "PMID 38159879: Patient muscle immunofluorescence showed aggrephagy pathway proteins p62, NBR1, and LC3B accumulated in intranuclear inclusions, suggesting the LOC642361/NUTM2B-AS1 CGG expansion may impair aggrephagic capacity.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:38159879",
+      "Evidence detail": "PMID 38159879: Patient muscle immunofluorescence showed RNA-binding proteins hnRNPA1, hnRNPA2B1, and MBNL1 accumulated in intranuclear inclusions, consistent with repeat-associated RNA-binding protein sequestration.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:38159879",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:38159879",
+      "Evidence detail": "PMID 38159879: Patient muscle biopsies showed myopathic changes with rimmed vacuoles, p62-positive intranuclear inclusions, filamentous aggregates by electron microscopy, autophagic vacuoles, and swollen/disordered mitochondria.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-02-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -4066,8 +4081,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 2.5,
     "Genetic Evidence": 7.5
   },


### PR DESCRIPTION
## Description

Updated the OPML1/NUTM2B-AS1 criTRia entry by adding a concise root-level description and improving evidence detail fields for probands, segregation, biochemical function, protein interaction, and patient-cell evidence. The regulatory impact evidence detail was left blank/pending curator review because the cited paper does not clearly support a positive regulatory-impact finding.

Fixes: # https://github.com/dashnowlab/STRchive/issues/420

## Major Changes

- None

## Minor Changes

- Added root-level OPML1/NUTM2B-AS1 disease-locus description
- Replaced vague/null evidence details with concise PMID-supported summaries
- Clarified proband evidence across PMID:31332380, PMID:37923380, and PMID:39308795
- Added segregation detail from PMID:31332380
- Added experimental evidence details from PMID:38159879
- Flagged regulatory impact evidence for curator review

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR