### PR TITLE
EIF4A3–RCPS curation details

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2426,69 +2426,80 @@
   "Inheritance": "AR",
   "Curator": "Laurel Hiatt",
   "Date": "06/02/2025",
-  "Description": null,
+  "Description": "Richieri-Costa-Pereira syndrome (RCPS) is an autosomal recessive acrofacial dysostosis caused primarily by biallelic EIF4A3 5' UTR repeat expansions, most commonly 15-16 repeats compared with 3-12 repeats in controls, with additional pathogenic compound heterozygosity involving a 14-repeat allele and EIF4A3 missense variant. The locus-disease relationship is supported by affected families/probands with biallelic EIF4A3 variants, linkage and segregation at 17q25.3, reduced EIF4A3 expression and neural crest/osteochondrogenic defects in patient-derived cells, and zebrafish and mouse models of EIF4A3 deficiency that reproduce craniofacial developmental abnormalities relevant to RCPS.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": "",
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6,
-    "Citation": "pmid:29112243",
-    "Evidence detail": "6 families with clinical characterization, sequencing etc.",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2018-04-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 3,
-    "Citation": "pmid:24360810",
-    "Evidence detail": "LoD score 9.533, WES",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2014-01-02"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6,
+      "Citation": "pmid:29112243",
+      "Evidence detail": "Seven affected individuals from six families had RCPS clinical features and biallelic EIF4A3 variants involving 14-, 15-, or 16-repeat 5' UTR expansion alleles and/or c.809A>G in trans; the cohort included mild and severe presentations and expanded the phenotypic/genotypic spectrum.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2018-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 3,
+      "Citation": "pmid:24360810",
+      "Evidence detail": "Linkage and segregation in 20 affected individuals from 17 families refined the RCPS locus to 17q25.3 and showed significant linkage at rs2289534 (maximum LOD 9.533); expanded EIF4A3 5' UTR alleles segregated with autosomal-recessive disease in tested families.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2014-01-02"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Patient cells",
-    "Score": 2,
-    "Citation": "pmid:28334780",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2017-06-15"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 3,
-    "Citation": "pmid:28334780",
-    "Evidence detail": "Conditional mouse model ",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2017-06-15"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2,
-    "Citation": "pmid:24360810",
-    "Evidence detail": "Zebrafish ",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2014-01-02"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Patient cells",
+      "Score": 2,
+      "Citation": "pmid:28334780",
+      "Evidence detail": "RCPS patient-derived iPSCs were differentiated into iNCCs and nMSCs; RCPS iNCCs showed reduced EIF4A3 mRNA/protein and decreased wound-healing migration, while nMSCs showed altered chondrogenic markers and premature osteogenic differentiation.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2017-06-15"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 3,
+      "Citation": "pmid:28334780",
+      "Evidence detail": "Gene-level, not repeat-allele-specific: conditional Eif4a3 haploinsufficient mouse models, including NCC-specific Wnt1-Cre;Eif4a3lx/+ embryos, showed RCPS-relevant craniofacial defects including impaired mandibular development, micrognathia, reduced Meckel's cartilage, premature clavicle ossification, and mandibular hypoplasia.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2017-06-15"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2,
+      "Citation": "pmid:24360810",
+      "Evidence detail": "Gene-level, not repeat-allele-specific: zebrafish eif4a3 morpholino knockdown caused craniofacial cartilage and bone underdevelopment, lower-jaw clefting, and underdeveloped pharyngeal arches; most abnormalities were rescued by eif4a3-EGFP mRNA.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2014-01-02"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6,
     "Collective Evidence": 3,
     "Statistics": 0,
@@ -2497,8 +2508,7 @@
     "Models": 4,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
     "Genetic Evidence": 9
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2431,75 +2431,64 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": "",
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6,
-      "Citation": "pmid:29112243",
-      "Evidence detail": "Seven affected individuals from six families had RCPS clinical features and biallelic EIF4A3 variants involving 14-, 15-, or 16-repeat 5' UTR expansion alleles and/or c.809A>G in trans; the cohort included mild and severe presentations and expanded the phenotypic/genotypic spectrum.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2018-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 3,
-      "Citation": "pmid:24360810",
-      "Evidence detail": "Linkage and segregation in 20 affected individuals from 17 families refined the RCPS locus to 17q25.3 and showed significant linkage at rs2289534 (maximum LOD 9.533); expanded EIF4A3 5' UTR alleles segregated with autosomal-recessive disease in tested families.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2014-01-02"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6,
+    "Citation": "pmid:29112243",
+    "Evidence detail": "Seven affected individuals from six families had RCPS clinical features and biallelic EIF4A3 variants involving 14-, 15-, or 16-repeat 5' UTR expansion alleles and/or c.809A>G in trans; the cohort included mild and severe presentations and expanded the phenotypic/genotypic spectrum.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2018-04-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 3,
+    "Citation": "pmid:24360810",
+    "Evidence detail": "Linkage and segregation in 20 affected individuals from 17 families refined the RCPS locus to 17q25.3 and showed significant linkage at rs2289534 (maximum LOD 9.533); expanded EIF4A3 5' UTR alleles segregated with autosomal-recessive disease in tested families.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2014-01-02"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Patient cells",
-      "Score": 2,
-      "Citation": "pmid:28334780",
-      "Evidence detail": "RCPS patient-derived iPSCs were differentiated into iNCCs and nMSCs; RCPS iNCCs showed reduced EIF4A3 mRNA/protein and decreased wound-healing migration, while nMSCs showed altered chondrogenic markers and premature osteogenic differentiation.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2017-06-15"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 3,
-      "Citation": "pmid:28334780",
-      "Evidence detail": "Gene-level, not repeat-allele-specific: conditional Eif4a3 haploinsufficient mouse models, including NCC-specific Wnt1-Cre;Eif4a3lx/+ embryos, showed RCPS-relevant craniofacial defects including impaired mandibular development, micrognathia, reduced Meckel's cartilage, premature clavicle ossification, and mandibular hypoplasia.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2017-06-15"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2,
-      "Citation": "pmid:24360810",
-      "Evidence detail": "Gene-level, not repeat-allele-specific: zebrafish eif4a3 morpholino knockdown caused craniofacial cartilage and bone underdevelopment, lower-jaw clefting, and underdeveloped pharyngeal arches; most abnormalities were rescued by eif4a3-EGFP mRNA.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2014-01-02"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Patient cells",
+    "Score": 2,
+    "Citation": "pmid:28334780",
+    "Evidence detail": "RCPS patient-derived iPSCs were differentiated into iNCCs and nMSCs; RCPS iNCCs showed reduced EIF4A3 mRNA/protein and decreased wound-healing migration, while nMSCs showed altered chondrogenic markers and premature osteogenic differentiation.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2017-06-15"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 3,
+    "Citation": "pmid:28334780",
+    "Evidence detail": "Gene-level, not repeat-allele-specific: conditional Eif4a3 haploinsufficient mouse models, including NCC-specific Wnt1-Cre;Eif4a3lx/+ embryos, showed RCPS-relevant craniofacial defects including impaired mandibular development, micrognathia, reduced Meckel's cartilage, premature clavicle ossification, and mandibular hypoplasia.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2017-06-15"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2,
+    "Citation": "pmid:24360810",
+    "Evidence detail": "Gene-level, not repeat-allele-specific: zebrafish eif4a3 morpholino knockdown caused craniofacial cartilage and bone underdevelopment, lower-jaw clefting, and underdeveloped pharyngeal arches; most abnormalities were rescued by eif4a3-EGFP mRNA.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2014-01-02"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6,
     "Collective Evidence": 3,
     "Statistics": 0,
@@ -2508,7 +2497,8 @@
     "Models": 4,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 9
   },


### PR DESCRIPTION
## Description

Updated the EIF4A3–RCPS criTRia curation by improving the root-level description and replacing vague/null evidence details with concise, source-supported summaries.

Fixes: #

## Major Changes

* None

## Minor Changes

* Added a root-level `Description` for the EIF4A3–RCPS locus-disease relationship.
* Clarified proband evidence from PMID:29112243, including affected individuals/families and biallelic EIF4A3 repeat/missense variants.
* Clarified segregation evidence from PMID:24360810, including the 17q25.3 linkage region and LOD score.
* Added patient-cell evidence detail from PMID:28334780 describing iPSC-derived neural crest and mesenchymal cell findings.
* Clarified mouse and zebrafish model evidence, explicitly noting that these are gene-level EIF4A3 deficiency models rather than repeat-allele-specific models.
* No scores, evidence rows, summaries, classification, or publication metadata were changed.

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
