### PR TITLE
CHNG3_MIR7-2-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3905,75 +3905,64 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:38714869",
-      "Evidence detail": "STR3 or STR4* variants in the 15q TTTG STR were identified in 12 unrelated RTSH families; all 76 phenotypically assessed affected participants were heterozygous for STRmut, with 6 additional STRmut carriers whose pretreatment thyroid phenotype could not be assessed.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2024-05-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:38714868",
-      "Evidence detail": "Linkage analysis in family A identified a chr15q26.1 critical interval overlapping the TTTG STR (GRCh38 chr15:86,206,051-89,412,131; maximum LOD score 4.8), with the (TTTG)3 allele tracking with thyroid abnormalities in the pedigree.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2024-05-01"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 6.0,
-      "Citation": "pmid:38714868",
-      "Evidence detail": "In a congenital hypothyroidism cohort, (TTTG)3/SNV variants were found in 137/989 cases (13.9%) versus 3/38,722 Japanese population controls (P<1e-300); an independent MNG cohort also showed enrichment (3/33 cases; P<1.2e-8 versus controls).",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "2024-05-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:38714869",
+    "Evidence detail": "STR3 or STR4* variants in the 15q TTTG STR were identified in 12 unrelated RTSH families; all 76 phenotypically assessed affected participants were heterozygous for STRmut, with 6 additional STRmut carriers whose pretreatment thyroid phenotype could not be assessed.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2024-05-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:38714868",
+    "Evidence detail": "Linkage analysis in family A identified a chr15q26.1 critical interval overlapping the TTTG STR (GRCh38 chr15:86,206,051-89,412,131; maximum LOD score 4.8), with the (TTTG)3 allele tracking with thyroid abnormalities in the pedigree.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2024-05-01"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 6.0,
+    "Citation": "pmid:38714868",
+    "Evidence detail": "In a congenital hypothyroidism cohort, (TTTG)3/SNV variants were found in 137/989 cases (13.9%) versus 3/38,722 Japanese population controls (P<1e-300); an independent MNG cohort also showed enrichment (3/33 cases; P<1.2e-8 versus controls).",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2024-05-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:38714868",
-      "Evidence detail": "Locus-specific regulatory evidence: snATAC-seq placed the (TTTG)4 region in thyroid-selective open chromatin, and luciferase assays in FRTL-5 and HEK293 cells showed WT repressor activity that was attenuated by (TTTG)3/SNV variants.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-05-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:38714868",
-      "Evidence detail": "Patient-derived thyroid tissue from an adult (TTTG)3 carrier with MNG showed benign nodular pathology, heterogeneous follicle size, increased resorptive vacuoles, and thyroglobulin staining.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-05-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:38714868",
+    "Evidence detail": "Locus-specific regulatory evidence: snATAC-seq placed the (TTTG)4 region in thyroid-selective open chromatin, and luciferase assays in FRTL-5 and HEK293 cells showed WT repressor activity that was attenuated by (TTTG)3/SNV variants.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-05-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:38714868",
+    "Evidence detail": "Patient-derived thyroid tissue from an adult (TTTG)3 carrier with MNG showed benign nodular pathology, heterogeneous follicle size, increased resorptive vacuoles, and thyroglobulin staining.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-05-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 6.0,
@@ -3982,7 +3971,8 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 1.5,
     "Genetic Evidence": 12
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3900,69 +3900,80 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "Noncoding TTTG STR changes at 15q26.1 between DET1 and MIR7-2/MIR1179 are associated with autosomal dominant CHNG3/resistance to TSH, presenting as congenital nongoitrous hypothyroidism and/or multinodular goiter. Two 2024 studies reported recurrent (TTTG)3 deletions and STR SNVs segregating in families and enriched in congenital hypothyroidism/MNG cohorts, with locus-specific functional evidence that the STR has thyroid-specific regulatory activity and that pathogenic STR variants disrupt or activate regulatory programs affecting MIR7-2/MIR1179 expression in thyroid tissue.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:38714869",
-    "Evidence detail": "12.0",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2024-05-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:38714868",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2024-05-01"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 6.0,
-    "Citation": "pmid:38714868",
-    "Evidence detail": null,
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2024-05-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:38714869",
+      "Evidence detail": "STR3 or STR4* variants in the 15q TTTG STR were identified in 12 unrelated RTSH families; all 76 phenotypically assessed affected participants were heterozygous for STRmut, with 6 additional STRmut carriers whose pretreatment thyroid phenotype could not be assessed.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2024-05-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:38714868",
+      "Evidence detail": "Linkage analysis in family A identified a chr15q26.1 critical interval overlapping the TTTG STR (GRCh38 chr15:86,206,051-89,412,131; maximum LOD score 4.8), with the (TTTG)3 allele tracking with thyroid abnormalities in the pedigree.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2024-05-01"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 6.0,
+      "Citation": "pmid:38714868",
+      "Evidence detail": "In a congenital hypothyroidism cohort, (TTTG)3/SNV variants were found in 137/989 cases (13.9%) versus 3/38,722 Japanese population controls (P<1e-300); an independent MNG cohort also showed enrichment (3/33 cases; P<1.2e-8 versus controls).",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "2024-05-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:38714868",
-    "Evidence detail": "expression",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-05-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:38714868",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-05-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:38714868",
+      "Evidence detail": "Locus-specific regulatory evidence: snATAC-seq placed the (TTTG)4 region in thyroid-selective open chromatin, and luciferase assays in FRTL-5 and HEK293 cells showed WT repressor activity that was attenuated by (TTTG)3/SNV variants.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-05-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:38714868",
+      "Evidence detail": "Patient-derived thyroid tissue from an adult (TTTG)3 carrier with MNG showed benign nodular pathology, heterogeneous follicle size, increased resorptive vacuoles, and thyroglobulin staining.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-05-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.5,
     "Statistics": 6.0,
@@ -3971,8 +3982,7 @@
     "Models": 0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 1.5,
     "Genetic Evidence": 12
   },


### PR DESCRIPTION
## Description

Update the MIR7-2_CHNG3 criTRia entry by refining the root-level description and improving existing evidence detail fields for the CHNG3/MIR7-2 locus based on the provided 2024 literature. No scores, summaries, classifications, or schema fields were changed. :contentReference[oaicite:0]{index=0}

Fixes: # 

## Major Changes

- None

## Minor Changes

- Added a concise disease/locus description for CHNG3/MIR7-2.
- Expanded vague or missing evidence details for:
  - Probands
  - Segregation
  - Case-control data
  - Regulatory impact
  - Patient cells
- Clarified locus-specific regulatory evidence involving the 15q26.1 TTTG STR and MIR7-2/MIR1179 expression.

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR