### PR TITLE
TOF_TBX1-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6138,36 +6138,31 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 1,
-      "Citation": "pmid:19948535",
-      "Evidence detail": "One female proband from a 230-patient ToF cohort carried TBX1 c.1399-1428dup30, an in-frame 30-bp polyalanine expansion; the variant was absent in 185 controls, mother was negative, and father was unavailable. Phenotype included ToF with absent pulmonary valve, isolated left pulmonary artery, additional VSD, scoliosis, and no 22q11.2-typical facial gestalt; functional testing showed severely reduced transcriptional activity and protein aggregation, but segregation was unavailable.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2010-05-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 1,
+    "Citation": "pmid:19948535",
+    "Evidence detail": "One female proband from a 230-patient ToF cohort carried TBX1 c.1399-1428dup30, an in-frame 30-bp polyalanine expansion; the variant was absent in 185 controls, mother was negative, and father was unavailable. Phenotype included ToF with absent pulmonary valve, isolated left pulmonary artery, additional VSD, scoliosis, and no 22q11.2-typical facial gestalt; functional testing showed severely reduced transcriptional activity and protein aggregation, but segregation was unavailable.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2010-05-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 1,
-      "Citation": "pmid:16141220",
-      "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: timed conditional Tbx1 deletion in mouse embryos caused pharyngeal and cardiovascular developmental defects, including aortic arch patterning and outflow tract abnormalities; the study supports Tbx1 developmental function but does not model the human TBX1 polyalanine repeat expansion.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2005-10-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 1,
+    "Citation": "pmid:16141220",
+    "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: timed conditional Tbx1 deletion in mouse embryos caused pharyngeal and cardiovascular developmental defects, including aortic arch patterning and outflow tract abnormalities; the study supports Tbx1 developmental function but does not model the human TBX1 polyalanine repeat expansion.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2005-10-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 1,
     "Collective Evidence": 0,
     "Statistics": 0,
@@ -6176,7 +6171,8 @@
     "Models": 1,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 1,
     "Genetic Evidence": 1
   },
@@ -6184,8 +6180,7 @@
   "publication_count": 2,
   "publication_interval_years": 4.58,
   "classification": "Limited"
-}
-,
+},
 {
   "Disease_ID": "FECD3",
   "Gene": "TCF4",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -6133,36 +6133,41 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "TBX1_TOF curation is based on one tetralogy of Fallot (ToF) proband with a heterozygous 30-bp polyalanine expansion in TBX1 (c.1399-1428dup30) reported in a 230-patient ToF cohort. The proband had ToF with absent pulmonary valve, isolated left pulmonary artery, additional VSD, scoliosis, and limited extracardiac features; functional testing showed severely reduced transcriptional activity and protein aggregation. Gene-level mouse Tbx1 timed-deletion studies support roles in pharyngeal and cardiovascular development, including aortic arch and outflow tract defects, but are not tandem-repeat/locus-specific.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 1,
-    "Citation": "pmid:19948535",
-    "Evidence detail": "no family genetics, pheno info | 1 proband",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2010-05-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 1,
+      "Citation": "pmid:19948535",
+      "Evidence detail": "One female proband from a 230-patient ToF cohort carried TBX1 c.1399-1428dup30, an in-frame 30-bp polyalanine expansion; the variant was absent in 185 controls, mother was negative, and father was unavailable. Phenotype included ToF with absent pulmonary valve, isolated left pulmonary artery, additional VSD, scoliosis, and no 22q11.2-typical facial gestalt; functional testing showed severely reduced transcriptional activity and protein aggregation, but segregation was unavailable.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2010-05-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 1,
-    "Citation": "pmid:16141220",
-    "Evidence detail": "Mouse | whole gene not locus-specific",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2005-10-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 1,
+      "Citation": "pmid:16141220",
+      "Evidence detail": "Gene-level, not tandem-repeat/locus-specific: timed conditional Tbx1 deletion in mouse embryos caused pharyngeal and cardiovascular developmental defects, including aortic arch patterning and outflow tract abnormalities; the study supports Tbx1 developmental function but does not model the human TBX1 polyalanine repeat expansion.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2005-10-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 1,
     "Collective Evidence": 0,
     "Statistics": 0,
@@ -6171,8 +6176,7 @@
     "Models": 1,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 1,
     "Genetic Evidence": 1
   },
@@ -6180,7 +6184,8 @@
   "publication_count": 2,
   "publication_interval_years": 4.58,
   "classification": "Limited"
-},
+}
+,
 {
   "Disease_ID": "FECD3",
   "Gene": "TCF4",


### PR DESCRIPTION
## Description

Updated the TBX1_TOF criTRia curation by refining the root-level description and improving evidence details for the existing proband and mouse model evidence rows. No scores, evidence rows, summaries, total score, classification, publication count, or publication interval were changed. :contentReference[oaicite:0]{index=0}

Fixes: # **Link to any relevant issues and/or discussions**

## Major Changes

- None

## Minor Changes

- Added a concise curation description for TBX1_TOF.
- Clarified the proband evidence from PMID:19948535, including the TBX1 c.1399-1428dup30 polyalanine expansion, ToF phenotype, control status, parental testing limitation, and functional findings.
- Clarified that the PMID:16141220 mouse model evidence is gene-level Tbx1 developmental evidence and not tandem-repeat/locus-specific.
- Preserved all original scores and classification as Limited.

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR