### PR TITLE
HOXD_SD5-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3258,18 +3258,18 @@
     "Singular Evidence": 6.0,
     "Collective Evidence": 2.5,
     "Statistics": 0,
-    "Function": 1.5,
-    "Functional Alteration": 1.5,
+    "Function": 0,
+    "Functional Alteration": 0,
     "Models": 4.0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 6,
+    "Experimental Evidence": 4.0,
     "Genetic Evidence": 8.5
   },
-  "total_score": 14.5,
-  "publication_count": 4,
+  "total_score": 12.5,
+  "publication_count": 3,
   "publication_interval_years": 24.09,
   "classification": "Definitive"
 },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3203,113 +3203,132 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "Autosomal dominant synpolydactyly type 5 is associated with in-frame polyalanine expansions in exon 1 of HOXD13, a coding tandem-repeat tract outside the DNA-binding homeodomain. Published families show HOXD13 polyalanine expansions segregating with synpolydactyly, with expansion size correlating with penetrance and limb phenotype severity. Functional studies in a Hoxd13 +7A synpolydactyly mouse model and transcription-factor condensate assays support a repeat-expansion mechanism that alters HOXD13 condensate composition and downstream transcriptional programs during limb development.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:9207113",
-    "Evidence detail": "16.0",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["1997-07-08"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1.0,
-    "Citation": "pmid:9207113",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["1997-07-08"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:8614804",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["1996-04-26"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:9207113",
+      "Evidence detail": "Sixteen newly ascertained SPD pedigrees and 4 previously published pedigrees were clinically/genetically reviewed; HOXD13 exon 1 polyalanine expansions of +7, +8, +9, +10, or +14 alanines were identified, with 99 affected individuals examined.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "1997-07-08"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1.0,
+      "Citation": "pmid:9207113",
+      "Evidence detail": "Across 20 SPD pedigrees, larger HOXD13 polyalanine expansions correlated with higher penetrance and greater limb involvement; nonpenetrance was observed only with the smallest (+7 alanine) expansions, and severity increased significantly for hands (P=0.012) and feet (P<0.00005).",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "1997-07-08"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:8614804",
+      "Evidence detail": "In three SPD pedigrees, HOXD13 polyalanine expansion alleles cosegregated with synpolydactyly; affected individuals carried larger PCR products, one homozygous individual had a more severe phenotype, and one clinically unaffected relative was a nonpenetrant heterozygous carrier.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "1996-04-26"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:22406499",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 4.0,
-    "Citation": "pmid:32386547",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2020-05-28"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:22406499",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2012-05-10"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:22406499",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2012-05-10"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:22406499",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2012-05-10"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:22406499",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2012-05-10"
+      ]
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:22406499",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2012-05-10"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 4.0,
+      "Citation": "pmid:32386547",
+      "Evidence detail": "Homozygous spdh mouse embryos carrying the Hoxd13 +7A repeat-expansion allele showed synpolydactyly-relevant limb bud defects, altered HOXD13-containing condensates, reduced co-activator overlap, and cell-type-specific transcriptional changes in disease-relevant limb cells.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2020-05-28"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 2.5,
     "Statistics": 0,
@@ -3318,8 +3337,7 @@
     "Models": 4.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
     "Genetic Evidence": 8.5
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3208,127 +3208,108 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:9207113",
-      "Evidence detail": "Sixteen newly ascertained SPD pedigrees and 4 previously published pedigrees were clinically/genetically reviewed; HOXD13 exon 1 polyalanine expansions of +7, +8, +9, +10, or +14 alanines were identified, with 99 affected individuals examined.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "1997-07-08"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1.0,
-      "Citation": "pmid:9207113",
-      "Evidence detail": "Across 20 SPD pedigrees, larger HOXD13 polyalanine expansions correlated with higher penetrance and greater limb involvement; nonpenetrance was observed only with the smallest (+7 alanine) expansions, and severity increased significantly for hands (P=0.012) and feet (P<0.00005).",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "1997-07-08"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:8614804",
-      "Evidence detail": "In three SPD pedigrees, HOXD13 polyalanine expansion alleles cosegregated with synpolydactyly; affected individuals carried larger PCR products, one homozygous individual had a more severe phenotype, and one clinically unaffected relative was a nonpenetrant heterozygous carrier.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "1996-04-26"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:9207113",
+    "Evidence detail": "Sixteen newly ascertained SPD pedigrees and 4 previously published pedigrees were clinically/genetically reviewed; HOXD13 exon 1 polyalanine expansions of +7, +8, +9, +10, or +14 alanines were identified, with 99 affected individuals examined.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["1997-07-08"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1.0,
+    "Citation": "pmid:9207113",
+    "Evidence detail": "Across 20 SPD pedigrees, larger HOXD13 polyalanine expansions correlated with higher penetrance and greater limb involvement; nonpenetrance was observed only with the smallest (+7 alanine) expansions, and severity increased significantly for hands (P=0.012) and feet (P<0.00005).",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["1997-07-08"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:8614804",
+    "Evidence detail": "In three SPD pedigrees, HOXD13 polyalanine expansion alleles cosegregated with synpolydactyly; affected individuals carried larger PCR products, one homozygous individual had a more severe phenotype, and one clinically unaffected relative was a nonpenetrant heterozygous carrier.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["1996-04-26"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:22406499",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2012-05-10"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:22406499",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2012-05-10"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:22406499",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2012-05-10"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:22406499",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2012-05-10"
-      ]
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:22406499",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2012-05-10"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 4.0,
-      "Citation": "pmid:32386547",
-      "Evidence detail": "Homozygous spdh mouse embryos carrying the Hoxd13 +7A repeat-expansion allele showed synpolydactyly-relevant limb bud defects, altered HOXD13-containing condensates, reduced co-activator overlap, and cell-type-specific transcriptional changes in disease-relevant limb cells.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2020-05-28"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:22406499",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2012-05-10"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:22406499",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2012-05-10"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:22406499",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2012-05-10"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:22406499",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2012-05-10"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:22406499",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_dates": ["2012-05-10"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 4.0,
+    "Citation": "pmid:32386547",
+    "Evidence detail": "Homozygous spdh mouse embryos carrying the Hoxd13 +7A repeat-expansion allele showed synpolydactyly-relevant limb bud defects, altered HOXD13-containing condensates, reduced co-activator overlap, and cell-type-specific transcriptional changes in disease-relevant limb cells.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2020-05-28"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 2.5,
     "Statistics": 0,
@@ -3337,7 +3318,8 @@
     "Models": 4.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 8.5
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3243,61 +3243,6 @@
   }],
   "experimental_evidence_details": [
   {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:22406499",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:22406499",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2012-05-10"]
-  },
-  {
     "Evidence type": "Non-human model organism",
     "Score": 4.0,
     "Citation": "pmid:32386547",


### PR DESCRIPTION

Updated the HOXD13_SD5 criTRia JSON evidence details and root-level description for the HOXD13 polyalanine expansion locus associated with autosomal dominant synpolydactyly type 5. The update replaces null/vague evidence-detail fields with concise curator-style summaries while preserving the original schema, scores, category summaries, total score, classification, publication count, and publication interval.

Fixes: # https://github.com/dashnowlab/STRchive/issues/437

## Major Changes

* Added a root-level disease/locus description for **HOXD13_SD5**, summarizing the association between HOXD13 exon 1 polyalanine expansions and synpolydactyly type 5.
* Updated genetic evidence details for:

  * Probands
  * Allele/expansion-size correlation
  * Segregation
* Updated the non-human model organism evidence detail using the Hoxd13 +7A synpolydactyly mouse model and transcriptional condensate findings.

## Minor Changes

* Clarified evidence details without changing any assigned scores.
* Preserved existing `category_summary`, `supercategory_summary`, `total_score`, `classification`, `publication_count`, and `publication_interval_years`.
* Left several experimental evidence rows citing **pmid:22406499** blank/flagged for curator review because the source supports clinical/molecular variant identification but does not appear to provide direct functional assays for biochemical function, protein interaction, regulatory impact, patient cells, or non-patient cells. 
* https://github.com/dashnowlab/STRchive/issues/437

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
