### PR TITLE
SCA17-TBP-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5871,6 +5871,17 @@
     "category_max_score": 2,
     "publication_dates": ["2022-07-21", "2020-05-28"]
   },
+  { 
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:32386547",
+    "Evidence detail": "experimental evidence using engineered constructs in non‑patient cells and in vitro systems. Pathogenic polyglutamine expansion in the TBP N‑terminal disordered region disrupts its normal phase separation behavior, providing a potential molecular mechanism for SCA17.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2008-03-28"]
+  },
   {
     "Evidence type": "Non-human model organism",
     "Score": 2,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5828,7 +5828,7 @@
   "genetic_evidence_details": [
   {
     "Evidence type": "Probands",
-    "Score": 6,
+    "Score": 6.0,
     "Citation": "pmid:12805114",
     "Evidence detail": "Two unrelated HDL probands carried TBP CAG/CAA expansions (44 and 46 repeats) after exclusion of HTT CAG expansions; both had early-onset behavioral/gait symptoms, ataxia, and dementia, with one also showing chorea.",
     "evidence_category": "Singular Evidence",
@@ -5839,7 +5839,7 @@
   },
   {
     "Evidence type": "Allele",
-    "Score": 2,
+    "Score": 2.0,
     "Citation": "pmid:12805114",
     "Evidence detail": "Expanded alleles comprised 44 and 46 CAG/CAA repeats; the 46-repeat allele was inherited from an unaffected 59-year-old father, supporting reduced penetrance in the low-expansion range.",
     "evidence_category": "Collective Evidence",
@@ -5850,7 +5850,7 @@
   },
   {
     "Evidence type": "Case-control data",
-    "Score": 2,
+    "Score": 2.0,
     "Citation": "pmid:27172828; pmid:26374734; pmid:26267067",
     "Evidence detail": "PMIDs 26374734 and 27172828 support association of low-range TBP expansions with SCA17/PD phenotypes in Thai cohorts, while PMID 26267067 found overlapping 41–44 repeat frequencies in Korean patients and controls; low-range alleles require cautious interpretation.",
     "evidence_category": "Statistics",
@@ -5862,7 +5862,7 @@
   "experimental_evidence_details": [
   {
     "Evidence type": "Regulatory impact",
-    "Score": 1,
+    "Score": 1.0,
     "Citation": "pmid:35868859; pmid:32386547",
     "Evidence detail": "PMID 32386547 showed disease-associated TBP polyQ expansion altered phase-separation behavior of TBP-containing transcriptional condensates; PMID 35868859 is TAF1/XDP-focused and is not TBP/SCA17 locus-specific.",
     "evidence_category": "Function",
@@ -5871,20 +5871,20 @@
     "category_max_score": 2,
     "publication_dates": ["2022-07-21", "2020-05-28"]
   },
-  { 
+  {
     "Evidence type": "Non-patient cells",
     "Score": 0.5,
     "Citation": "pmid:32386547",
     "Evidence detail": "experimental evidence using engineered constructs in non‑patient cells and in vitro systems. Pathogenic polyglutamine expansion in the TBP N‑terminal disordered region disrupts its normal phase separation behavior, providing a potential molecular mechanism for SCA17.",
     "evidence_category": "Functional Alteration",
     "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
+    "evidence_max_score": 1,
     "category_max_score": 2,
     "publication_dates": ["2008-03-28"]
   },
   {
     "Evidence type": "Non-human model organism",
-    "Score": 2,
+    "Score": 2.0,
     "Citation": "pmid:18218637",
     "Evidence detail": "Transgenic mice expressing truncated polyQ-expanded TBP developed neuronal nuclear inclusions and severe early neurological phenotypes/early death, supporting in vivo neurotoxicity of expanded TBP.",
     "evidence_category": "Models",
@@ -5895,20 +5895,20 @@
   }],
   "category_summary":
   {
-    "Singular Evidence": 6,
-    "Collective Evidence": 2,
-    "Statistics": 2,
-    "Function": 1,
-    "Functional Alteration": 0,
-    "Models": 2,
+    "Singular Evidence": 6.0,
+    "Collective Evidence": 2.0,
+    "Statistics": 2.0,
+    "Function": 1.0,
+    "Functional Alteration": 0.5,
+    "Models": 2.0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 3,
-    "Genetic Evidence": 10
+    "Experimental Evidence": 3.5,
+    "Genetic Evidence": 10.0
   },
-  "total_score": 13,
+  "total_score": 13.5,
   "publication_count": 7,
   "publication_interval_years": 19.06,
   "classification": "Definitive"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5826,103 +5826,86 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6,
-      "Citation": "pmid:12805114",
-      "Evidence detail": "Two unrelated HDL probands carried TBP CAG/CAA expansions (44 and 46 repeats) after exclusion of HTT CAG expansions; both had early-onset behavioral/gait symptoms, ataxia, and dementia, with one also showing chorea.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2003-07-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 2,
-      "Citation": "pmid:12805114",
-      "Evidence detail": "Expanded alleles comprised 44 and 46 CAG/CAA repeats; the 46-repeat allele was inherited from an unaffected 59-year-old father, supporting reduced penetrance in the low-expansion range.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2003-07-01"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 6,
-      "Citation": "pmid:27172828; pmid:26374734; pmid:26267067",
-      "Evidence detail": "PMIDs 26374734 and 27172828 support association of low-range TBP expansions with SCA17/PD phenotypes in Thai cohorts, while PMID 26267067 found overlapping 41–44 repeat frequencies in Korean patients and controls; low-range alleles require cautious interpretation.",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "2016-07-01",
-        "2015-09-15",
-        "2015-01-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6,
+    "Citation": "pmid:12805114",
+    "Evidence detail": "Two unrelated HDL probands carried TBP CAG/CAA expansions (44 and 46 repeats) after exclusion of HTT CAG expansions; both had early-onset behavioral/gait symptoms, ataxia, and dementia, with one also showing chorea.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2003-07-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 2,
+    "Citation": "pmid:12805114",
+    "Evidence detail": "Expanded alleles comprised 44 and 46 CAG/CAA repeats; the 46-repeat allele was inherited from an unaffected 59-year-old father, supporting reduced penetrance in the low-expansion range.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2003-07-01"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 6,
+    "Citation": "pmid:27172828; pmid:26374734; pmid:26267067",
+    "Evidence detail": "PMIDs 26374734 and 27172828 support association of low-range TBP expansions with SCA17/PD phenotypes in Thai cohorts, while PMID 26267067 found overlapping 41–44 repeat frequencies in Korean patients and controls; low-range alleles require cautious interpretation.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2016-07-01", "2015-09-15", "2015-01-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 1,
-      "Citation": "pmid:35868859; pmid:32386547",
-      "Evidence detail": "PMID 32386547 showed disease-associated TBP polyQ expansion altered phase-separation behavior of TBP-containing transcriptional condensates; PMID 35868859 is TAF1/XDP-focused and is not TBP/SCA17 locus-specific.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2022-07-21",
-        "2020-05-28"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 2,
-      "Citation": "pmid:32386547; pmid:18218637",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2020-05-28",
-        "2008-03-28"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2,
-      "Citation": "pmid:18218637",
-      "Evidence detail": "Transgenic mice expressing truncated polyQ-expanded TBP developed neuronal nuclear inclusions and severe early neurological phenotypes/early death, supporting in vivo neurotoxicity of expanded TBP.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2008-03-28"
-      ]
-    },
-    {
-      "Evidence type": "Cell culture",
-      "Score": 1,
-      "Citation": null,
-      "Evidence detail": "",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": []
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 1,
+    "Citation": "pmid:35868859; pmid:32386547",
+    "Evidence detail": "PMID 32386547 showed disease-associated TBP polyQ expansion altered phase-separation behavior of TBP-containing transcriptional condensates; PMID 35868859 is TAF1/XDP-focused and is not TBP/SCA17 locus-specific.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2022-07-21", "2020-05-28"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 2,
+    "Citation": "pmid:32386547; pmid:18218637",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2020-05-28", "2008-03-28"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2,
+    "Citation": "pmid:18218637",
+    "Evidence detail": "Transgenic mice expressing truncated polyQ-expanded TBP developed neuronal nuclear inclusions and severe early neurological phenotypes/early death, supporting in vivo neurotoxicity of expanded TBP.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2008-03-28"]
+  },
+  {
+    "Evidence type": "Cell culture",
+    "Score": 1,
+    "Citation": null,
+    "Evidence detail": "",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": []
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6,
     "Collective Evidence": 2,
     "Statistics": 6,
@@ -5931,7 +5914,8 @@
     "Models": 3,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5850,7 +5850,7 @@
   },
   {
     "Evidence type": "Case-control data",
-    "Score": 6,
+    "Score": 2,
     "Citation": "pmid:27172828; pmid:26374734; pmid:26267067",
     "Evidence detail": "PMIDs 26374734 and 27172828 support association of low-range TBP expansions with SCA17/PD phenotypes in Thai cohorts, while PMID 26267067 found overlapping 41–44 repeat frequencies in Korean patients and controls; low-range alleles require cautious interpretation.",
     "evidence_category": "Statistics",
@@ -5872,17 +5872,6 @@
     "publication_dates": ["2022-07-21", "2020-05-28"]
   },
   {
-    "Evidence type": "Patient cells",
-    "Score": 2,
-    "Citation": "pmid:32386547; pmid:18218637",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2020-05-28", "2008-03-28"]
-  },
-  {
     "Evidence type": "Non-human model organism",
     "Score": 2,
     "Citation": "pmid:18218637",
@@ -5892,17 +5881,6 @@
     "evidence_max_score": 4,
     "category_max_score": 4,
     "publication_dates": ["2008-03-28"]
-  },
-  {
-    "Evidence type": "Cell culture",
-    "Score": 1,
-    "Citation": null,
-    "Evidence detail": "",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": []
   }],
   "category_summary":
   {

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5821,91 +5821,108 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "Spinocerebellar ataxia type 17 (SCA17) is an autosomal dominant neurodegenerative disorder caused by CAG/CAA repeat expansion in the coding polyglutamine tract of TBP. Reported phenotypes include cerebellar ataxia, cognitive/psychiatric symptoms, chorea, dystonia, parkinsonism, and Huntington disease-like presentations. Genetic evidence includes unrelated probands with TBP expansions and population studies supporting pathogenicity of expanded alleles, although low-range alleles show reduced penetrance and uncertain thresholds. Experimental evidence supports altered TBP transcription-related function, condensate behavior, aggregation, and neurotoxicity in model systems.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6,
-    "Citation": "pmid:12805114",
-    "Evidence detail": "2 probands",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2003-07-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 2,
-    "Citation": "pmid:12805114",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2003-07-01"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 6,
-    "Citation": "pmid:27172828; pmid:26374734; pmid:26267067",
-    "Evidence detail": null,
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2016-07-01", "2015-09-15", "2015-01-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6,
+      "Citation": "pmid:12805114",
+      "Evidence detail": "Two unrelated HDL probands carried TBP CAG/CAA expansions (44 and 46 repeats) after exclusion of HTT CAG expansions; both had early-onset behavioral/gait symptoms, ataxia, and dementia, with one also showing chorea.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2003-07-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 2,
+      "Citation": "pmid:12805114",
+      "Evidence detail": "Expanded alleles comprised 44 and 46 CAG/CAA repeats; the 46-repeat allele was inherited from an unaffected 59-year-old father, supporting reduced penetrance in the low-expansion range.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2003-07-01"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 6,
+      "Citation": "pmid:27172828; pmid:26374734; pmid:26267067",
+      "Evidence detail": "PMIDs 26374734 and 27172828 support association of low-range TBP expansions with SCA17/PD phenotypes in Thai cohorts, while PMID 26267067 found overlapping 41–44 repeat frequencies in Korean patients and controls; low-range alleles require cautious interpretation.",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "2016-07-01",
+        "2015-09-15",
+        "2015-01-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 1,
-    "Citation": "pmid:35868859; pmid:32386547",
-    "Evidence detail": "transcription alteration and change in brain expression",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2022-07-21", "2020-05-28"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 2,
-    "Citation": "pmid:32386547; pmid:18218637",
-    "Evidence detail": " cherry + tissue specific protein interactions ",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2020-05-28", "2008-03-28"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2,
-    "Citation": "pmid:18218637",
-    "Evidence detail": " transgenic mice + cultured cells",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2008-03-28"]
-  },
-  {
-    "Evidence type": "Cell culture",
-    "Score": 1,
-    "Citation": null,
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": []
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 1,
+      "Citation": "pmid:35868859; pmid:32386547",
+      "Evidence detail": "PMID 32386547 showed disease-associated TBP polyQ expansion altered phase-separation behavior of TBP-containing transcriptional condensates; PMID 35868859 is TAF1/XDP-focused and is not TBP/SCA17 locus-specific.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2022-07-21",
+        "2020-05-28"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 2,
+      "Citation": "pmid:32386547; pmid:18218637",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2020-05-28",
+        "2008-03-28"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2,
+      "Citation": "pmid:18218637",
+      "Evidence detail": "Transgenic mice expressing truncated polyQ-expanded TBP developed neuronal nuclear inclusions and severe early neurological phenotypes/early death, supporting in vivo neurotoxicity of expanded TBP.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2008-03-28"
+      ]
+    },
+    {
+      "Evidence type": "Cell culture",
+      "Score": 1,
+      "Citation": null,
+      "Evidence detail": "",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": []
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6,
     "Collective Evidence": 2,
     "Statistics": 6,
@@ -5914,8 +5931,7 @@
     "Models": 3,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5886,18 +5886,18 @@
   {
     "Singular Evidence": 6,
     "Collective Evidence": 2,
-    "Statistics": 6,
+    "Statistics": 2,
     "Function": 1,
-    "Functional Alteration": 2,
-    "Models": 3,
+    "Functional Alteration": 0,
+    "Models": 2,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 6,
-    "Genetic Evidence": 12
+    "Experimental Evidence": 3,
+    "Genetic Evidence": 10
   },
-  "total_score": 18,
+  "total_score": 13,
   "publication_count": 7,
   "publication_interval_years": 19.06,
   "classification": "Definitive"


### PR DESCRIPTION
## Description

Updated the criTRia curation entry for **TBP_SCA17** by improving the root-level description and refining evidence details for existing evidence rows. No scores, categories, summaries, classification, publication counts, or schema fields were changed.

Fixes: # [**Link to relevant curator-review issue**](https://github.com/dashnowlab/STRchive/issues/439)

## Major Changes

- None

## Minor Changes

- Added a concise disease/locus description for **SCA17_TBP**.
- Expanded vague or missing evidence details for:
  - Probands
  - Allele evidence
  - Case-control data
  - Regulatory impact
  - Non-human model organism
- Flagged rows needing curator review where evidence is missing or not clearly matched to the assigned evidence type:
  - Patient cells evidence appears unsupported by the cited sources.
  - Cell culture evidence has no citation.
  - Regulatory impact includes one citation that appears TAF1/XDP-focused rather than TBP/SCA17-specific.
- Clarified that low-range TBP repeat evidence has mixed interpretation because some cohorts support association while others show overlap with controls.
https://github.com/dashnowlab/STRchive/issues/439
## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If breaking change, increment X.
- [ ] Ask someone to review this PR