### PR TITLE
HOXA13 / HFG-I -critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -3016,17 +3016,17 @@
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
-    "Function": 1.0,
+    "Function": 0.5,
     "Functional Alteration": 0,
     "Models": 2.0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 3.0,
+    "Experimental Evidence": 2.5,
     "Genetic Evidence": 3.0
   },
-  "total_score": 6.0,
+  "total_score": 5.5,
   "publication_count": 2,
   "publication_interval_years": 1.63,
   "classification": "Limited"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2990,21 +2990,10 @@
   }],
   "experimental_evidence_details": [
   {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:15385446; pmid:12676922",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2004-11-15", "2003-04-01"]
-  },
-  {
     "Evidence type": "Regulatory impact",
     "Score": 0.5,
     "Citation": "pmid:15385446; pmid:12676922",
-    "Evidence detail": "",
+    "Evidence detail": "Gene-level support for HOXA13 polyalanine expansion mechanisms, including reduced protein abundance/degradation and possible dominant-negative effects",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
@@ -3015,7 +3004,7 @@
     "Evidence type": "Non-human model organism",
     "Score": 2.0,
     "Citation": "pmid:15385446",
-    "Evidence detail": "Gene-level, not HFG-II-specific: engineered Hoxa13 tract-III polyalanine-expansion mice (Hoxa13Ala28) showed limb phenotypes indistinguishable from Hoxa13 null mice and no homozygote survival to birth, supporting loss of function for HOXA13 polyalanine expansions.",
+    "Evidence detail": "Gene-level, not HFG-II-specific: engineered Hoxa13 tract-III polyalanine-expansion mice (Hoxa13Ala28) showed limb phenotypes indistinguishable from Hoxa13 null mice and no homozygote survival to birth, supporting loss of function for HOXA13 polyalanine expansions. This evidence is not specific to tract-II, but supports the gene and the effect of polyalanine expansions in the gene.",
     "evidence_category": "Models",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 4,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2961,69 +2961,82 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/18/2025",
-  "Description": null,
+  "Description": "Autosomal dominant hand-foot-genital syndrome type II (HFG-II) is supported by a heterozygous 18 bp in-frame duplication in the second HOXA13 polyalanine tract, adding six alanines. The locus-specific human evidence comes from a six-generation family with 27 affected individuals, atypical HFGS with mild limb findings and high hypospadias penetrance, significant linkage to chromosome 7p (maximum LOD 6.70 at D7S503), segregation of the HOXA13-II duplication in available affected relatives, and absence of the duplication from 100 Swedish controls.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 1.5,
-    "Citation": "pmid:12676922",
-    "Evidence detail": "1.0",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2003-04-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:12676922",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2003-04-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 1.5,
+      "Citation": "pmid:12676922",
+      "Evidence detail": "One six-generation family with 27 affected individuals and atypical HFGS carried a heterozygous 18 bp duplication in the second HOXA13 polyalanine tract (+6 alanines); the variant was absent from 100 Swedish controls.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2003-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:12676922",
+      "Evidence detail": "Genome-wide linkage mapped the trait to chromosome 7p with maximum LOD 6.70 at θ=0 for D7S503; the HOXA13-II duplication was observed in all available affected family members, with one apparently unaffected carrier noted.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2003-04-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:15385446; pmid:12676922",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2004-11-15", "2003-04-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:15385446; pmid:12676922",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2004-11-15", "2003-04-01"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:15385446",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2004-11-15"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:15385446; pmid:12676922",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2004-11-15",
+        "2003-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:15385446; pmid:12676922",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2004-11-15",
+        "2003-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:15385446",
+      "Evidence detail": "Gene-level, not HFG-II-specific: engineered Hoxa13 tract-III polyalanine-expansion mice (Hoxa13Ala28) showed limb phenotypes indistinguishable from Hoxa13 null mice and no homozygote survival to birth, supporting loss of function for HOXA13 polyalanine expansions.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2004-11-15"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -3032,8 +3045,7 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 3.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2966,77 +2966,64 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 1.5,
-      "Citation": "pmid:12676922",
-      "Evidence detail": "One six-generation family with 27 affected individuals and atypical HFGS carried a heterozygous 18 bp duplication in the second HOXA13 polyalanine tract (+6 alanines); the variant was absent from 100 Swedish controls.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2003-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:12676922",
-      "Evidence detail": "Genome-wide linkage mapped the trait to chromosome 7p with maximum LOD 6.70 at θ=0 for D7S503; the HOXA13-II duplication was observed in all available affected family members, with one apparently unaffected carrier noted.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2003-04-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 1.5,
+    "Citation": "pmid:12676922",
+    "Evidence detail": "One six-generation family with 27 affected individuals and atypical HFGS carried a heterozygous 18 bp duplication in the second HOXA13 polyalanine tract (+6 alanines); the variant was absent from 100 Swedish controls.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2003-04-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:12676922",
+    "Evidence detail": "Genome-wide linkage mapped the trait to chromosome 7p with maximum LOD 6.70 at θ=0 for D7S503; the HOXA13-II duplication was observed in all available affected family members, with one apparently unaffected carrier noted.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2003-04-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:15385446; pmid:12676922",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2004-11-15",
-        "2003-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:15385446; pmid:12676922",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2004-11-15",
-        "2003-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:15385446",
-      "Evidence detail": "Gene-level, not HFG-II-specific: engineered Hoxa13 tract-III polyalanine-expansion mice (Hoxa13Ala28) showed limb phenotypes indistinguishable from Hoxa13 null mice and no homozygote survival to birth, supporting loss of function for HOXA13 polyalanine expansions.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2004-11-15"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:15385446; pmid:12676922",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2004-11-15", "2003-04-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:15385446; pmid:12676922",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2004-11-15", "2003-04-01"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:15385446",
+    "Evidence detail": "Gene-level, not HFG-II-specific: engineered Hoxa13 tract-III polyalanine-expansion mice (Hoxa13Ala28) showed limb phenotypes indistinguishable from Hoxa13 null mice and no homozygote survival to birth, supporting loss of function for HOXA13 polyalanine expansions.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2004-11-15"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -3045,7 +3032,8 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 3.0
   },


### PR DESCRIPTION
Updated the HOXA13 / HFG-II criTRia entry by adding a root-level description and improving curator-facing evidence details for supported genetic and experimental evidence rows.

Fixes: [# **Link to any relevant issues and/or discussions**](https://github.com/dashnowlab/STRchive/issues/445)

## Major Changes

- Added a concise disease/locus description for **HOXA13 / HFG-II**, summarizing the heterozygous 18 bp in-frame duplication in the second HOXA13 polyalanine tract and the supporting human evidence.
- Updated genetic evidence details for:
  - **Probands**
  - **Segregation**
- Added clearer experimental evidence detail for the **Non-human model organism** row, noting that the mouse model evidence is gene-level and not HFG-II-locus-specific.

## Minor Changes

- Replaced vague or missing evidence details with concise curator-style descriptions.
- Preserved all existing scores, evidence rows, category summaries, supercategory summaries, total score, classification, publication count, and publication interval.
- Left unsupported/unclear experimental evidence rows blank for curator review rather than changing scores or evidence structure.
https://github.com/dashnowlab/STRchive/issues/445

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR