### PR TITLE
SCA31_BEAN1-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1349,16 +1349,16 @@
     "Collective Evidence": 1.0,
     "Statistics": 2.0,
     "Function": 2.0,
-    "Functional Alteration": 2,
-    "Models": 2.0,
+    "Functional Alteration": 1.0,
+    "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 6,
+    "Experimental Evidence": 3.0,
     "Genetic Evidence": 9.0
   },
-  "total_score": 15.0,
+  "total_score": 12.0,
   "publication_count": 4,
   "publication_interval_years": 13.33,
   "classification": "Definitive"

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1265,127 +1265,108 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:19878914",
-      "Evidence detail": "The pathogenic 2.5–3.8 kb BEAN1/TK2 intronic repeat insertion containing (TGGAA)n was identified in 160 affected individuals from 98 SCA31 families.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2009-11-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1.0,
-      "Citation": "pmid:19878914",
-      "Evidence detail": "Insertion length inversely correlated with age at onset (r = -0.41, p = 0.010, n = 39), with subtle expansion documented in one family showing mild anticipation.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2009-11-01"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 2.0,
-      "Citation": "pmid:19878914",
-      "Evidence detail": "The SCA31 insertion was found in affected individuals and was absent from 21 disease controls and SCA4 subjects; 2/860 control chromosomes carried shorter insertions lacking (TGGAA)n and were considered non-pathogenic.",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "2009-11-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:19878914",
+    "Evidence detail": "The pathogenic 2.5–3.8 kb BEAN1/TK2 intronic repeat insertion containing (TGGAA)n was identified in 160 affected individuals from 98 SCA31 families.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2009-11-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1.0,
+    "Citation": "pmid:19878914",
+    "Evidence detail": "Insertion length inversely correlated with age at onset (r = -0.41, p = 0.010, n = 39), with subtle expansion documented in one family showing mild anticipation.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2009-11-01"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 2.0,
+    "Citation": "pmid:19878914",
+    "Evidence detail": "The SCA31 insertion was found in affected individuals and was absent from 21 disease controls and SCA4 subjects; 2/860 control chromosomes carried shorter insertions lacking (TGGAA)n and were considered non-pathogenic.",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["2009-11-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:36371266",
-      "Evidence detail": "BEAN1 (TGGAA)n repeat is transcribed to (UGGAA)n RNA that forms RNA foci in Purkinje cells and binds TDP-43, FUS, and hnRNP A2/B1.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2023-03-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:36563608",
-      "Evidence detail": "Review-level, locus-specific evidence: TDP-43 is described as suppressing (UGGAA)n-mediated neurotoxicity; original interaction experiments are cited within the review but not presented in this source.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2023-01-15"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 1.0,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "Review-level, locus-specific evidence: the (TGGAA)n-containing insertion lies in the BEAN/TK2 shared intronic region and insertion length inversely correlates with age at onset, supporting length-dependent toxicity.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:36563608",
-      "Evidence detail": "Review-level evidence: the source summarizes neurotoxic RNA foci in human SCA31 Purkinje cells; original patient-cell experimental data are not presented in this review.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2023-01-15"
-      ]
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 2.0,
-      "Citation": "pmid:36563608",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2023-01-15"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:36371266",
+    "Evidence detail": "BEAN1 (TGGAA)n repeat is transcribed to (UGGAA)n RNA that forms RNA foci in Purkinje cells and binds TDP-43, FUS, and hnRNP A2/B1.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2023-03-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:36563608",
+    "Evidence detail": "Review-level, locus-specific evidence: TDP-43 is described as suppressing (UGGAA)n-mediated neurotoxicity; original interaction experiments are cited within the review but not presented in this source.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2023-01-15"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 1.0,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "Review-level, locus-specific evidence: the (TGGAA)n-containing insertion lies in the BEAN/TK2 shared intronic region and insertion length inversely correlates with age at onset, supporting length-dependent toxicity.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2013-01-18"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:36563608",
+    "Evidence detail": "Review-level evidence: the source summarizes neurotoxic RNA foci in human SCA31 Purkinje cells; original patient-cell experimental data are not presented in this review.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2023-01-15"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 2.0,
+    "Citation": "pmid:36563608",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_dates": ["2023-01-15"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2013-01-18"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 2.0,
@@ -1394,7 +1375,8 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 9.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1260,113 +1260,132 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/11/2025",
-  "Description": null,
+  "Description": "SCA31 is an autosomal dominant, late-onset progressive cerebellar ataxia associated with a 2.5–3.8 kb complex pentanucleotide repeat insertion containing pathogenic (TGGAA)n at the shared intronic BEAN1/TK2 locus. The insertion was reported in 160 affected individuals from 98 SCA31 families, was absent from disease controls and SCA4 subjects, and rare control insertions were shorter and lacked the (TGGAA)n component. Repeat insertion length inversely correlates with age at onset, and patient Purkinje cells show sense-direction RNA foci, supporting a toxic RNA gain-of-function mechanism. The locus-disease relationship is classified as Definitive.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:19878914",
-    "Evidence detail": "98 probands",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2009-11-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1.0,
-    "Citation": "pmid:19878914",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2009-11-01"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 2.0,
-    "Citation": "pmid:19878914",
-    "Evidence detail": "only 2 controls",
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["2009-11-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:19878914",
+      "Evidence detail": "The pathogenic 2.5–3.8 kb BEAN1/TK2 intronic repeat insertion containing (TGGAA)n was identified in 160 affected individuals from 98 SCA31 families.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2009-11-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1.0,
+      "Citation": "pmid:19878914",
+      "Evidence detail": "Insertion length inversely correlated with age at onset (r = -0.41, p = 0.010, n = 39), with subtle expansion documented in one family showing mild anticipation.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2009-11-01"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 2.0,
+      "Citation": "pmid:19878914",
+      "Evidence detail": "The SCA31 insertion was found in affected individuals and was absent from 21 disease controls and SCA4 subjects; 2/860 control chromosomes carried shorter insertions lacking (TGGAA)n and were considered non-pathogenic.",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "2009-11-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:36371266",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2023-03-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:36563608",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2023-01-15"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 1.0,
-    "Citation": "pmid:23331413",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:36563608",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2023-01-15"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 2.0,
-    "Citation": "pmid:36563608",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2023-01-15"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:23331413",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2013-01-18"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:36371266",
+      "Evidence detail": "BEAN1 (TGGAA)n repeat is transcribed to (UGGAA)n RNA that forms RNA foci in Purkinje cells and binds TDP-43, FUS, and hnRNP A2/B1.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2023-03-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:36563608",
+      "Evidence detail": "Review-level, locus-specific evidence: TDP-43 is described as suppressing (UGGAA)n-mediated neurotoxicity; original interaction experiments are cited within the review but not presented in this source.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2023-01-15"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 1.0,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "Review-level, locus-specific evidence: the (TGGAA)n-containing insertion lies in the BEAN/TK2 shared intronic region and insertion length inversely correlates with age at onset, supporting length-dependent toxicity.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:36563608",
+      "Evidence detail": "Review-level evidence: the source summarizes neurotoxic RNA foci in human SCA31 Purkinje cells; original patient-cell experimental data are not presented in this review.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2023-01-15"
+      ]
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 2.0,
+      "Citation": "pmid:36563608",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2023-01-15"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 2.0,
@@ -1375,8 +1394,7 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
     "Genetic Evidence": 9.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1342,28 +1342,6 @@
     "evidence_max_score": 2,
     "category_max_score": 2,
     "publication_dates": ["2023-01-15"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 2.0,
-    "Citation": "pmid:36563608",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2023-01-15"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:23331413",
-    "Evidence detail": "",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2013-01-18"]
   }],
   "category_summary":
   {


### PR DESCRIPTION
Updated the BEAN1 / SCA31 criTRia entry by filling the root-level Description and improving existing Evidence detail fields using the provided source papers. The update clarifies the pathogenic (TGGAA)n-containing BEAN1/TK2 intronic insertion, affected cohort size, allele length correlation with age at onset, control observations, and review-level experimental evidence.

Issues: https://github.com/dashnowlab/STRchive/issues/451

Major Changes

Minor Changes
Added a concise root-level Description for BEAN1 / SCA31.
Updated vague or missing Evidence detail fields for:
Probands
Allele
Case-control data
Biochemical function
Protein interaction
Regulatory impact
Patient cells
Left curator-review items for unsupported/unclear experimental evidence rows:
Non-patient cells
Non-human model organism
https://github.com/dashnowlab/STRchive/issues/451
