### PR TITLE
SCA6_CACNA1A-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1481,8 +1481,8 @@
     "Collective Evidence": 3,
     "Statistics": 6.0,
     "Function": 2,
-    "Functional Alteration": 1.5,
-    "Models": 4,
+    "Functional Alteration": 0,
+    "Models": 2.0,
     "Rescue": 2.0
   },
   "supercategory_summary":

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1432,32 +1432,10 @@
     "publication_dates": ["1997-01-01"]
   },
   {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:8988170",
-    "Evidence detail": ".",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1997-01-01"]
-  },
-  {
     "Evidence type": "Biochemical function",
     "Score": 0.5,
     "Citation": "pmid:23331413",
     "Evidence detail": "Secondary review: CACNA1A is the P/Q-type alpha1A calcium-channel gene for SCA6, and the SCA6 expansion encodes an expanded polyglutamine tract. The review also discusses RNAi-based post-transcriptional silencing as a therapeutic concept, not primary locus-specific data.",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": "",
     "evidence_category": "Function",
     "evidence_supercategory": "Experimental Evidence",
     "evidence_max_score": 2,
@@ -1474,39 +1452,6 @@
     "evidence_max_score": 2,
     "category_max_score": 2,
     "publication_dates": ["1997-01-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:23331413",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": "Secondary review: summarizes splice-isoform-specific RNAi targeting the polyQ-encoding Cav2.1/CACNA1A variant as a potential SCA6 therapy; primary non-patient cell data are not included in the supplied source.",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 3.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": "",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2013-01-18"]
   },
   {
     "Evidence type": "Non-human model organism",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1370,168 +1370,197 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/12/2025",
-  "Description": null,
+  "Description": "Spinocerebellar ataxia type 6 (SCA6) is an autosomal dominant, late-onset, slowly progressive cerebellar ataxia caused by expansion of a CAG repeat in CACNA1A, encoding an expanded polyglutamine tract in the alpha1A/P/Q-type calcium-channel gene product/alpha1ACT. Expanded alleles were initially observed in unrelated ataxia cases and absent from controls, segregate or share disease haplotypes in families, and repeat-unit number influences age at onset and threshold interpretation. Functional evidence supports Purkinje-cell vulnerability and a toxic gain-of-function mechanism involving CACNA1A C-terminal/alpha1ACT biology, with rescue of model phenotypes by reducing IRES-driven alpha1ACTSCA6 translation.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:39996131",
-    "Evidence detail": null,
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2025-04-01"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:15026782",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2004-06-01"]
-  },
-  {
-    "Evidence type": "Case-control data",
-    "Score": 6.0,
-    "Citation": "pmid:8988170",
-    "Evidence detail": null,
-    "evidence_category": "Statistics",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 12,
-    "category_max_score": 12,
-    "publication_dates": ["1997-01-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 2.0,
-    "Citation": "pmid:39996131",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2025-04-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:39996131",
+      "Evidence detail": "Observational cohort of 2,768 individuals tested for CACNA1A CAG repeat units; results support SCA6 diagnosis at >=21 repeat units, with 19-20 repeat units interpreted as an intermediate range requiring opposite-allele and clinical context.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2025-04-01"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:15026782",
+      "Evidence detail": "In 12 Dutch SCA6 families, 8 shared a CACNA1A-region core haplotype between D19S1165 and D19S840 (3-3-6-22-3) that was absent from 80 control chromosomes; additional LD and genealogical data supported a founder haplotype.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2004-06-01"
+      ]
+    },
+    {
+      "Evidence type": "Case-control data",
+      "Score": 6.0,
+      "Citation": "pmid:8988170",
+      "Evidence detail": "Expanded CACNA1A CAG alleles (21-27 repeats) were found in 8/133 unrelated ataxia index cases and in 0/475 ethnically matched non-ataxia controls, whose alleles ranged from 4-16 repeats (Fisher exact P < 1e-5).",
+      "evidence_category": "Statistics",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 12,
+      "category_max_score": 12,
+      "publication_dates": [
+        "1997-01-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 2.0,
+      "Citation": "pmid:39996131",
+      "Evidence detail": "Repeat-unit number refines pathogenic interpretation: family history positivity increased above 19 repeat units and plateaued at >=23; >=23 repeat units appeared sufficient for disease regardless of opposite allele, while 19-20 repeat units were intermediate and 21-22 repeat units were modified by opposite-allele length.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2025-04-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:8988170",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1997-01-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:8988170",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1997-01-01"]
-  },
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": "transc silencing",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 1.5,
-    "Citation": "pmid:8988170",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1997-01-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:23331413",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 3.5,
-    "Citation": "pmid:23331413",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2013-01-18"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:27412786",
-    "Evidence detail": "mouse",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2016-07-13"]
-  },
-  {
-    "Evidence type": "Rescue in non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:27412786",
-    "Evidence detail": "mouse",
-    "evidence_category": "Rescue",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2016-07-13"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:8988170",
+      "Evidence detail": "CACNA1A encodes the alpha1A/P-Q-type voltage-dependent calcium-channel subunit; the SCA6 CAG repeat lies in the open reading frame of several isoforms and is predicted to encode an expanded polyglutamine tract.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1997-01-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:8988170",
+      "Evidence detail": ".",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1997-01-01"
+      ]
+    },
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "Secondary review: CACNA1A is the P/Q-type alpha1A calcium-channel gene for SCA6, and the SCA6 expansion encodes an expanded polyglutamine tract. The review also discusses RNAi-based post-transcriptional silencing as a therapeutic concept, not primary locus-specific data.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 1.5,
+      "Citation": "pmid:8988170",
+      "Evidence detail": "Alternative CACNA1A isoforms were identified; GGCAG insertion/splicing can place the CAG repeat within an extended open reading frame, making the repeat polyglutamine-coding in specific isoforms.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1997-01-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "Secondary review: summarizes splice-isoform-specific RNAi targeting the polyQ-encoding Cav2.1/CACNA1A variant as a potential SCA6 therapy; primary non-patient cell data are not included in the supplied source.",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 3.5,
+      "Citation": "pmid:23331413",
+      "Evidence detail": "",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2013-01-18"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:27412786",
+      "Evidence detail": "AAV9-mediated expression of CACNA1A IRES-driven alpha1ACT-Q33 in neonatal wild-type mice caused early-onset motor deficits, gait instability, Purkinje-cell degeneration, and approximately 50% Purkinje-cell loss.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2016-07-13"
+      ]
+    },
+    {
+      "Evidence type": "Rescue in non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:27412786",
+      "Evidence detail": "AAV9-miR-3191-5p reduced IRES-driven alpha1ACT-Q33 protein expression and rescued SCA6 mouse phenotypes, including Purkinje-cell degeneration, rotarod/open-field performance, and gait instability.",
+      "evidence_category": "Rescue",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2016-07-13"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 6.0,
@@ -1540,8 +1569,7 @@
     "Models": 4,
     "Rescue": 2.0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -1375,192 +1375,163 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:39996131",
-      "Evidence detail": "Observational cohort of 2,768 individuals tested for CACNA1A CAG repeat units; results support SCA6 diagnosis at >=21 repeat units, with 19-20 repeat units interpreted as an intermediate range requiring opposite-allele and clinical context.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2025-04-01"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:15026782",
-      "Evidence detail": "In 12 Dutch SCA6 families, 8 shared a CACNA1A-region core haplotype between D19S1165 and D19S840 (3-3-6-22-3) that was absent from 80 control chromosomes; additional LD and genealogical data supported a founder haplotype.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2004-06-01"
-      ]
-    },
-    {
-      "Evidence type": "Case-control data",
-      "Score": 6.0,
-      "Citation": "pmid:8988170",
-      "Evidence detail": "Expanded CACNA1A CAG alleles (21-27 repeats) were found in 8/133 unrelated ataxia index cases and in 0/475 ethnically matched non-ataxia controls, whose alleles ranged from 4-16 repeats (Fisher exact P < 1e-5).",
-      "evidence_category": "Statistics",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 12,
-      "category_max_score": 12,
-      "publication_dates": [
-        "1997-01-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 2.0,
-      "Citation": "pmid:39996131",
-      "Evidence detail": "Repeat-unit number refines pathogenic interpretation: family history positivity increased above 19 repeat units and plateaued at >=23; >=23 repeat units appeared sufficient for disease regardless of opposite allele, while 19-20 repeat units were intermediate and 21-22 repeat units were modified by opposite-allele length.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2025-04-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:39996131",
+    "Evidence detail": "Observational cohort of 2,768 individuals tested for CACNA1A CAG repeat units; results support SCA6 diagnosis at >=21 repeat units, with 19-20 repeat units interpreted as an intermediate range requiring opposite-allele and clinical context.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2025-04-01"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:15026782",
+    "Evidence detail": "In 12 Dutch SCA6 families, 8 shared a CACNA1A-region core haplotype between D19S1165 and D19S840 (3-3-6-22-3) that was absent from 80 control chromosomes; additional LD and genealogical data supported a founder haplotype.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2004-06-01"]
+  },
+  {
+    "Evidence type": "Case-control data",
+    "Score": 6.0,
+    "Citation": "pmid:8988170",
+    "Evidence detail": "Expanded CACNA1A CAG alleles (21-27 repeats) were found in 8/133 unrelated ataxia index cases and in 0/475 ethnically matched non-ataxia controls, whose alleles ranged from 4-16 repeats (Fisher exact P < 1e-5).",
+    "evidence_category": "Statistics",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 12,
+    "category_max_score": 12,
+    "publication_dates": ["1997-01-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 2.0,
+    "Citation": "pmid:39996131",
+    "Evidence detail": "Repeat-unit number refines pathogenic interpretation: family history positivity increased above 19 repeat units and plateaued at >=23; >=23 repeat units appeared sufficient for disease regardless of opposite allele, while 19-20 repeat units were intermediate and 21-22 repeat units were modified by opposite-allele length.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2025-04-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:8988170",
-      "Evidence detail": "CACNA1A encodes the alpha1A/P-Q-type voltage-dependent calcium-channel subunit; the SCA6 CAG repeat lies in the open reading frame of several isoforms and is predicted to encode an expanded polyglutamine tract.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1997-01-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:8988170",
-      "Evidence detail": ".",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1997-01-01"
-      ]
-    },
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "Secondary review: CACNA1A is the P/Q-type alpha1A calcium-channel gene for SCA6, and the SCA6 expansion encodes an expanded polyglutamine tract. The review also discusses RNAi-based post-transcriptional silencing as a therapeutic concept, not primary locus-specific data.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 1.5,
-      "Citation": "pmid:8988170",
-      "Evidence detail": "Alternative CACNA1A isoforms were identified; GGCAG insertion/splicing can place the CAG repeat within an extended open reading frame, making the repeat polyglutamine-coding in specific isoforms.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1997-01-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "Secondary review: summarizes splice-isoform-specific RNAi targeting the polyQ-encoding Cav2.1/CACNA1A variant as a potential SCA6 therapy; primary non-patient cell data are not included in the supplied source.",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 3.5,
-      "Citation": "pmid:23331413",
-      "Evidence detail": "",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2013-01-18"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:27412786",
-      "Evidence detail": "AAV9-mediated expression of CACNA1A IRES-driven alpha1ACT-Q33 in neonatal wild-type mice caused early-onset motor deficits, gait instability, Purkinje-cell degeneration, and approximately 50% Purkinje-cell loss.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2016-07-13"
-      ]
-    },
-    {
-      "Evidence type": "Rescue in non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:27412786",
-      "Evidence detail": "AAV9-miR-3191-5p reduced IRES-driven alpha1ACT-Q33 protein expression and rescued SCA6 mouse phenotypes, including Purkinje-cell degeneration, rotarod/open-field performance, and gait instability.",
-      "evidence_category": "Rescue",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2016-07-13"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:8988170",
+    "Evidence detail": "CACNA1A encodes the alpha1A/P-Q-type voltage-dependent calcium-channel subunit; the SCA6 CAG repeat lies in the open reading frame of several isoforms and is predicted to encode an expanded polyglutamine tract.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1997-01-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:8988170",
+    "Evidence detail": ".",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1997-01-01"]
+  },
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "Secondary review: CACNA1A is the P/Q-type alpha1A calcium-channel gene for SCA6, and the SCA6 expansion encodes an expanded polyglutamine tract. The review also discusses RNAi-based post-transcriptional silencing as a therapeutic concept, not primary locus-specific data.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2013-01-18"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2013-01-18"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 1.5,
+    "Citation": "pmid:8988170",
+    "Evidence detail": "Alternative CACNA1A isoforms were identified; GGCAG insertion/splicing can place the CAG repeat within an extended open reading frame, making the repeat polyglutamine-coding in specific isoforms.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1997-01-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2013-01-18"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "Secondary review: summarizes splice-isoform-specific RNAi targeting the polyQ-encoding Cav2.1/CACNA1A variant as a potential SCA6 therapy; primary non-patient cell data are not included in the supplied source.",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_dates": ["2013-01-18"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 3.5,
+    "Citation": "pmid:23331413",
+    "Evidence detail": "",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2013-01-18"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:27412786",
+    "Evidence detail": "AAV9-mediated expression of CACNA1A IRES-driven alpha1ACT-Q33 in neonatal wild-type mice caused early-onset motor deficits, gait instability, Purkinje-cell degeneration, and approximately 50% Purkinje-cell loss.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2016-07-13"]
+  },
+  {
+    "Evidence type": "Rescue in non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:27412786",
+    "Evidence detail": "AAV9-miR-3191-5p reduced IRES-driven alpha1ACT-Q33 protein expression and rescued SCA6 mouse phenotypes, including Purkinje-cell degeneration, rotarod/open-field performance, and gait instability.",
+    "evidence_category": "Rescue",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2016-07-13"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 3,
     "Statistics": 6.0,
@@ -1569,7 +1540,8 @@
     "Models": 4,
     "Rescue": 2.0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6,
     "Genetic Evidence": 12
   },


### PR DESCRIPTION
## Description

Updated the CACNA1A/SCA6 criTRia entry by filling previously null, vague, or incomplete `Evidence detail` fields and adding a root-level `Description`.

Issues: [#](https://github.com/dashnowlab/STRchive/issues/457)

## Major Changes

* Refined the SCA6/CACNA1A description to summarize the autosomal dominant CAG repeat expansion mechanism, disease phenotype, allele-threshold evidence, and supporting functional/model evidence.
* Added updated evidence details for genetic evidence rows, including probands, segregation, case-control data, and allele interpretation.
* Added clearer functional/model evidence details for CACNA1A isoforms, CAG/polyglutamine coding context, mouse model data, and rescue evidence.

## Minor Changes

* Clarified evidence rows supported by secondary review sources.
* Marked several experimental evidence rows as needing curator review where the cited PMID does not clearly support the assigned evidence type.
https://github.com/dashnowlab/STRchive/issues/457

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
