### PR TITLE
Update criTRia-curations.json

### DIFF
--- a/data/STRchive-loci.json
+++ b/data/STRchive-loci.json
@@ -3697,7 +3697,7 @@
   "id": "SCA12_PPP2R2B",
   "disease_id": "SCA12",
   "gene": "PPP2R2B",
-  "evidence": ["Definitive"],
+  "evidence": ["Moderate"],
   "chrom": "chr5",
   "start_hg38": 146878727,
   "stop_hg38": 146878759,

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4710,20 +4710,20 @@
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 0,
-    "Function": 2,
-    "Functional Alteration": 1.5,
-    "Models": 2.0,
+    "Function": 1.5,
+    "Functional Alteration": 0,
+    "Models": 0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 6.0,
+    "Experimental Evidence": 1.5,
     "Genetic Evidence": 7.0
   },
-  "total_score": 13.0,
-  "publication_count": 5,
+  "total_score": 8.5,
+  "publication_count": 3,
   "publication_interval_years": 24.58,
-  "classification": "Definitive"
+  "classification": "Moderate"
 },
 {
   "Disease_ID": "HSAN-VIII",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4649,140 +4649,119 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 6.0,
-      "Citation": "pmid:34711523",
-      "Evidence detail": "SCA12 is described as relatively frequent in a northern Indian endogamous community due to a founder effect, caused by PPP2R2B repeat expansion, rare outside India, and characterized initially by coarse action tremor with later cerebellar signs.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2021-11-01"
-      ]
-    },
-    {
-      "Evidence type": "Allele",
-      "Score": 1.0,
-      "Citation": "pmid:38467784",
-      "Evidence detail": "PPP2R2B SCA12 is listed as an autosomal dominant promoter CAG repeat expansion disorder with proposed gain-of-function/polyalanine and RAN-translation mechanisms; this is locus-specific but not primary allele-size correlation data.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2024-07-01"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:34711523",
+    "Evidence detail": "SCA12 is described as relatively frequent in a northern Indian endogamous community due to a founder effect, caused by PPP2R2B repeat expansion, rare outside India, and characterized initially by coarse action tremor with later cerebellar signs.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2021-11-01"]
+  },
+  {
+    "Evidence type": "Allele",
+    "Score": 1.0,
+    "Citation": "pmid:38467784",
+    "Evidence detail": "PPP2R2B SCA12 is listed as an autosomal dominant promoter CAG repeat expansion disorder with proposed gain-of-function/polyalanine and RAN-translation mechanisms; this is locus-specific but not primary allele-size correlation data.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 3,
+    "publication_dates": ["2024-07-01"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:10581021",
-      "Evidence detail": "Gene-level evidence: PPP2R2B encodes brain-specific PP2A-PR55β, a regulatory subunit of protein phosphatase PP2A; PP2A is implicated in cell-cycle progression, tau phosphorylation, and apoptosis. Not SCA12-repeat-specific functional proof.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1999-12-01"
-      ]
-    },
-    {
-      "Evidence type": "Protein interaction",
-      "Score": 0.5,
-      "Citation": "pmid:10581021",
-      "Evidence detail": "Gene-level evidence: PR55β/PPP2R2B is described as a regulatory subunit of the trimeric PP2A holoenzyme. This supports pathway context but is not a direct SCA12 repeat-expansion protein-interaction assay.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1999-12-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:10581021",
-      "Evidence detail": "Locus-specific regulatory context: the SCA12 CAG repeat lies in the 5′ region/putative 5′ UTR near PPP2R2B transcription-start and promoter elements; patient lymphoblastoid cells had no detectable PPP2R2B RNA or protein, so direct regulatory impact was not demonstrated in disease-relevant tissue.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "1999-12-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:11198281",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2001-01-01"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:11198281",
-      "Evidence detail": "",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2001-01-01"
-      ]
-    },
-    {
-      "Evidence type": "Patient cells",
-      "Score": 1.0,
-      "Citation": "pmid:37906407",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-06-01"
-      ]
-    },
-    {
-      "Evidence type": "Non-patient cells",
-      "Score": 0.5,
-      "Citation": "pmid:37906407",
-      "Evidence detail": "",
-      "evidence_category": "Functional Alteration",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 1,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-06-01"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 2.0,
-      "Citation": "pmid:37906407",
-      "Evidence detail": "",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2024-06-01"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:10581021",
+    "Evidence detail": "Gene-level evidence: PPP2R2B encodes brain-specific PP2A-PR55β, a regulatory subunit of protein phosphatase PP2A; PP2A is implicated in cell-cycle progression, tau phosphorylation, and apoptosis. Not SCA12-repeat-specific functional proof.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1999-12-01"]
+  },
+  {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:10581021",
+    "Evidence detail": "Gene-level evidence: PR55β/PPP2R2B is described as a regulatory subunit of the trimeric PP2A holoenzyme. This supports pathway context but is not a direct SCA12 repeat-expansion protein-interaction assay.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1999-12-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:10581021",
+    "Evidence detail": "Locus-specific regulatory context: the SCA12 CAG repeat lies in the 5′ region/putative 5′ UTR near PPP2R2B transcription-start and promoter elements; patient lymphoblastoid cells had no detectable PPP2R2B RNA or protein, so direct regulatory impact was not demonstrated in disease-relevant tissue.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["1999-12-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:11198281",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2001-01-01"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:11198281",
+    "Evidence detail": "",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2001-01-01"]
+  },
+  {
+    "Evidence type": "Patient cells",
+    "Score": 1.0,
+    "Citation": "pmid:37906407",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-06-01"]
+  },
+  {
+    "Evidence type": "Non-patient cells",
+    "Score": 0.5,
+    "Citation": "pmid:37906407",
+    "Evidence detail": "",
+    "evidence_category": "Functional Alteration",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 1,
+    "category_max_score": 2,
+    "publication_dates": ["2024-06-01"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 2.0,
+    "Citation": "pmid:37906407",
+    "Evidence detail": "",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2024-06-01"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 0,
@@ -4791,7 +4770,8 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 6.0,
     "Genetic Evidence": 7.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4644,124 +4644,145 @@
   "Inheritance": "AD",
   "Curator": "Macayla Weiner, Laurel Hiatt",
   "Date": "08/11/2025",
-  "Description": null,
+  "Description": "Spinocerebellar ataxia 12 (SCA12) is an autosomal dominant repeat expansion disorder associated with a CAG repeat expansion in the 5′ region/promoter of PPP2R2B. Reported families support segregation of expanded alleles with an adult-onset phenotype that often begins with coarse action tremor of the hands/head and later develops cerebellar ataxia; incomplete/age-dependent penetrance has been reported. The locus is rare globally but enriched in a northern Indian founder population. PPP2R2B encodes the brain-enriched PP2A-PR55β regulatory subunit; the pathogenic mechanism is still incompletely established, with proposed regulatory effects and possible gain-of-function/RAN-translation mechanisms.",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:34711523",
-    "Evidence detail": null,
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2021-11-01"]
-  },
-  {
-    "Evidence type": "Allele",
-    "Score": 1.0,
-    "Citation": "pmid:38467784",
-    "Evidence detail": null,
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 3,
-    "publication_dates": ["2024-07-01"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 6.0,
+      "Citation": "pmid:34711523",
+      "Evidence detail": "SCA12 is described as relatively frequent in a northern Indian endogamous community due to a founder effect, caused by PPP2R2B repeat expansion, rare outside India, and characterized initially by coarse action tremor with later cerebellar signs.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2021-11-01"
+      ]
+    },
+    {
+      "Evidence type": "Allele",
+      "Score": 1.0,
+      "Citation": "pmid:38467784",
+      "Evidence detail": "PPP2R2B SCA12 is listed as an autosomal dominant promoter CAG repeat expansion disorder with proposed gain-of-function/polyalanine and RAN-translation mechanisms; this is locus-specific but not primary allele-size correlation data.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2024-07-01"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:10581021",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1999-12-01"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:10581021",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1999-12-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:10581021",
-    "Evidence detail": null,
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["1999-12-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:11198281",
-    "Evidence detail": "Epigenetic change",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2001-01-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:11198281",
-    "Evidence detail": "splicing",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2001-01-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:37906407",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-06-01"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:37906407",
-    "Evidence detail": null,
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2024-06-01"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:37906407",
-    "Evidence detail": null,
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2024-06-01"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:10581021",
+      "Evidence detail": "Gene-level evidence: PPP2R2B encodes brain-specific PP2A-PR55β, a regulatory subunit of protein phosphatase PP2A; PP2A is implicated in cell-cycle progression, tau phosphorylation, and apoptosis. Not SCA12-repeat-specific functional proof.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1999-12-01"
+      ]
+    },
+    {
+      "Evidence type": "Protein interaction",
+      "Score": 0.5,
+      "Citation": "pmid:10581021",
+      "Evidence detail": "Gene-level evidence: PR55β/PPP2R2B is described as a regulatory subunit of the trimeric PP2A holoenzyme. This supports pathway context but is not a direct SCA12 repeat-expansion protein-interaction assay.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1999-12-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:10581021",
+      "Evidence detail": "Locus-specific regulatory context: the SCA12 CAG repeat lies in the 5′ region/putative 5′ UTR near PPP2R2B transcription-start and promoter elements; patient lymphoblastoid cells had no detectable PPP2R2B RNA or protein, so direct regulatory impact was not demonstrated in disease-relevant tissue.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "1999-12-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:11198281",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2001-01-01"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:11198281",
+      "Evidence detail": "",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2001-01-01"
+      ]
+    },
+    {
+      "Evidence type": "Patient cells",
+      "Score": 1.0,
+      "Citation": "pmid:37906407",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-06-01"
+      ]
+    },
+    {
+      "Evidence type": "Non-patient cells",
+      "Score": 0.5,
+      "Citation": "pmid:37906407",
+      "Evidence detail": "",
+      "evidence_category": "Functional Alteration",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 1,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-06-01"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 2.0,
+      "Citation": "pmid:37906407",
+      "Evidence detail": "",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2024-06-01"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 6.0,
     "Collective Evidence": 1.0,
     "Statistics": 0,
@@ -4770,8 +4791,7 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 6.0,
     "Genetic Evidence": 7.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4704,61 +4704,6 @@
     "evidence_max_score": 2,
     "category_max_score": 2,
     "publication_dates": ["1999-12-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:11198281",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2001-01-01"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:11198281",
-    "Evidence detail": "",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2001-01-01"]
-  },
-  {
-    "Evidence type": "Patient cells",
-    "Score": 1.0,
-    "Citation": "pmid:37906407",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-06-01"]
-  },
-  {
-    "Evidence type": "Non-patient cells",
-    "Score": 0.5,
-    "Citation": "pmid:37906407",
-    "Evidence detail": "",
-    "evidence_category": "Functional Alteration",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 1,
-    "category_max_score": 2,
-    "publication_dates": ["2024-06-01"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 2.0,
-    "Citation": "pmid:37906407",
-    "Evidence detail": "",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2024-06-01"]
   }],
   "category_summary":
   {


### PR DESCRIPTION
Updated the PPP2R2B/SCA12 criTRia entry by adding concise evidence details and a root-level description based on the uploaded sources. Several experimental evidence rows were marked as **Curator review needed** because the cited papers did not clearly support the assigned evidence type or only provided gene-level/speculative evidence rather than direct SCA12 repeat-expansion functional evidence.

Fixes: https://github.com/dashnowlab/STRchive/issues/460

## Major Changes

* None

## Minor Changes

* Added root-level `Description` for the PPP2R2B/SCA12 locus-disease relationship.
* Updated missing/null `Evidence detail` fields for genetic and experimental evidence rows.
* Clarified where evidence is locus-specific versus gene-level only.
* Flagged unsupported or uncertain evidence rows for curator review, including:
https://github.com/dashnowlab/STRchive/issues/460
  * `pmid:11198281` regulatory impact rows for epigenetic change and splicing.
  * `pmid:37906407` patient cells, non-patient cells, and non-human model organism rows.
* Preserved all scores, evidence rows, summaries, total score, classification, publication count, and schema structure.

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
