### PR TITLE
DMD_DMD-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2255,62 +2255,59 @@
   "classification": "Strong"
 },
 {
-    "Disease_ID": "DMD",
-    "Gene": "DMD",
-    "Locus_ID": "DMD_DMD",
-    "Inheritance": "XR",
-    "Curator": "Laurel Hiatt, Harriet Dashnow",
-    "Date": "05/14/2025",
-    "Description": "A GAA repeat expansion in DMD intron 62 was proposed as a possible contributor to Duchenne/Becker-like dystrophinopathy based on a single three-generation family in which affected female relatives carried expanded alleles and population controls in that study had smaller alleles [@pmid:27417533]. However, large population analyses found the proposed pathogenic genotype at frequencies far exceeding expectations for a highly penetrant early-onset X-linked disorder, supporting refutation of the DMD repeat expansion as a pathogenic disease-causing locus [@pmid:40140942].",
-    "Source": "criTRia",
-    "SOP_version": "criTRia v0",
-    "Manual_evidence_level": "Refuted",
-    "genetic_evidence_details": [
-      {
-        "Evidence type": "Probands",
-        "Score": 0,
-        "Citation": "pmid:27417533",
-        "Evidence detail": "Single three-generation family reported with a DMD intron 62 GAA expansion (~59-82 repeats); two affected female relatives had chronic myopathy/dystrophinopathy-compatible findings, but the paper states that the repeat's phenotypic impact remains unresolved.",
-        "evidence_category": "Singular Evidence",
-        "evidence_supercategory": "Genetic Evidence",
-        "evidence_max_score": 6,
-        "category_max_score": 6,
-        "publication_dates": [
-          "2016-08-01"
-        ]
-      },
-      {
-        "Evidence type": "Computational",
-        "Score": 0,
-        "Citation": "pmid:40140942",
-        "Evidence detail": "Large population analysis found proposed pathogenic genotypes at 4.705% in gnomAD males and 0.089% in gnomAD females, with similar expanded alleles in HPRC long-read data; these frequencies greatly exceed DMD prevalence, supporting the conclusion that the repeat expansion is unlikely to be pathogenic.",
-        "evidence_category": "Collective Evidence",
-        "evidence_supercategory": "Genetic Evidence",
-        "evidence_max_score": 3,
-        "category_max_score": 3,
-        "publication_dates": [
-          "2025-03-26"
-        ]
-      }
-    ],
-    "experimental_evidence_details": [],
-    "category_summary": {
-      "Singular Evidence": 0,
-      "Collective Evidence": 0,
-      "Statistics": 0,
-      "Function": 0,
-      "Functional Alteration": 0,
-      "Models": 0,
-      "Rescue": 0
-    },
-    "supercategory_summary": {
-      "Genetic Evidence": 0,
-      "Experimental Evidence": 0
-    },
-    "total_score": 0,
-    "publication_count": 2,
-    "publication_interval_years": 8.65,
-    "classification": "Refuted"
+  "Disease_ID": "DMD",
+  "Gene": "DMD",
+  "Locus_ID": "DMD_DMD",
+  "Inheritance": "XR",
+  "Curator": "Laurel Hiatt, Harriet Dashnow",
+  "Date": "05/14/2025",
+  "Description": "A GAA repeat expansion in DMD intron 62 was proposed as a possible contributor to Duchenne/Becker-like dystrophinopathy based on a single three-generation family in which affected female relatives carried expanded alleles and population controls in that study had smaller alleles [@pmid:27417533]. However, large population analyses found the proposed pathogenic genotype at frequencies far exceeding expectations for a highly penetrant early-onset X-linked disorder, supporting refutation of the DMD repeat expansion as a pathogenic disease-causing locus [@pmid:40140942].",
+  "Source": "criTRia",
+  "SOP_version": "criTRia v0",
+  "Manual_evidence_level": "Refuted",
+  "genetic_evidence_details": [
+  {
+    "Evidence type": "Probands",
+    "Score": 0,
+    "Citation": "pmid:27417533",
+    "Evidence detail": "Single three-generation family reported with a DMD intron 62 GAA expansion (~59-82 repeats); two affected female relatives had chronic myopathy/dystrophinopathy-compatible findings, but the paper states that the repeat's phenotypic impact remains unresolved.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2016-08-01"]
+  },
+  {
+    "Evidence type": "Computational",
+    "Score": 0,
+    "Citation": "pmid:40140942",
+    "Evidence detail": "Large population analysis found proposed pathogenic genotypes at 4.705% in gnomAD males and 0.089% in gnomAD females, with similar expanded alleles in HPRC long-read data; these frequencies greatly exceed DMD prevalence, supporting the conclusion that the repeat expansion is unlikely to be pathogenic.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2025-03-26"]
+  }],
+  "experimental_evidence_details": [],
+  "category_summary":
+  {
+    "Singular Evidence": 0,
+    "Collective Evidence": 0,
+    "Statistics": 0,
+    "Function": 0,
+    "Functional Alteration": 0,
+    "Models": 0,
+    "Rescue": 0
+  },
+  "supercategory_summary":
+  {
+    "Genetic Evidence": 0,
+    "Experimental Evidence": 0
+  },
+  "total_score": 0,
+  "publication_count": 2,
+  "publication_interval_years": 8.65,
+  "classification": "Refuted"
 },
 {
   "Disease_ID": "DM1",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2254,61 +2254,66 @@
   "publication_interval_years": 0.99,
   "classification": "Strong"
 },
-{
-  "Disease_ID": "DMD",
-  "Gene": "DMD",
-  "Locus_ID": "DMD_DMD",
-  "Inheritance": "XR",
-  "Curator": "Laurel Hiatt, Harriet Dashnow",
-  "Date": "05/14/2025",
-  "Description": "There is conflicting evidence for the association between this repeat expansion and Duchenne muscular dystrophy. The association was reported in a single family, from which the benign and pathogenic ranges were inferred from affected and unaffected family members [@pmid:27417533]. However, a subsequent study of the repeat expansion in a large population cohort found that the proposed pathogenic allele is present at a much higher frequency than expected for a highly penetrant early-onset condition, leading the authors to conclude that the repeat expansion is unlikely to be pathogenic [@pmid:40140942].",
-  "Source": "criTRia",
-  "SOP_version": "criTRia v0",
-  "Manual_evidence_level": "Refuted",
-  "genetic_evidence_details": [
+[
   {
-    "Evidence type": "Probands",
-    "Score": 0,
-    "Citation": "pmid:27417533",
-    "Evidence detail": "Single family",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2016-08-01"]
-  },
-  {
-    "Evidence type": "Computational",
-    "Score": 0,
-    "Citation": "pmid:40140942",
-    "Evidence detail": "The population frequency of the proposed pathogenic allele is 4.705% in males, much higher than expected for a highly penetrant early-onset condition. The paper concludes that the repeat expansion is unlikely to be pathogenic.",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2025-03-26"]
-  }],
-  "experimental_evidence_details": [],
-  "category_summary":
-  {
-    "Singular Evidence": 0,
-    "Collective Evidence": 0,
-    "Statistics": 0,
-    "Function": 0,
-    "Functional Alteration": 0,
-    "Models": 0,
-    "Rescue": 0
-  },
-  "supercategory_summary":
-  {
-    "Genetic Evidence": 0,
-    "Experimental Evidence": 0
-  },
-  "total_score": 0,
-  "publication_count": 2,
-  "publication_interval_years": 8.65,
-  "classification": "Refuted"
-},
+    "Disease_ID": "DMD",
+    "Gene": "DMD",
+    "Locus_ID": "DMD_DMD",
+    "Inheritance": "XR",
+    "Curator": "Laurel Hiatt, Harriet Dashnow",
+    "Date": "05/14/2025",
+    "Description": "A GAA repeat expansion in DMD intron 62 was proposed as a possible contributor to Duchenne/Becker-like dystrophinopathy based on a single three-generation family in which affected female relatives carried expanded alleles and population controls in that study had smaller alleles [@pmid:27417533]. However, large population analyses found the proposed pathogenic genotype at frequencies far exceeding expectations for a highly penetrant early-onset X-linked disorder, supporting refutation of the DMD repeat expansion as a pathogenic disease-causing locus [@pmid:40140942].",
+    "Source": "criTRia",
+    "SOP_version": "criTRia v0",
+    "Manual_evidence_level": "Refuted",
+    "genetic_evidence_details": [
+      {
+        "Evidence type": "Probands",
+        "Score": 0,
+        "Citation": "pmid:27417533",
+        "Evidence detail": "Single three-generation family reported with a DMD intron 62 GAA expansion (~59-82 repeats); two affected female relatives had chronic myopathy/dystrophinopathy-compatible findings, but the paper states that the repeat's phenotypic impact remains unresolved.",
+        "evidence_category": "Singular Evidence",
+        "evidence_supercategory": "Genetic Evidence",
+        "evidence_max_score": 6,
+        "category_max_score": 6,
+        "publication_dates": [
+          "2016-08-01"
+        ]
+      },
+      {
+        "Evidence type": "Computational",
+        "Score": 0,
+        "Citation": "pmid:40140942",
+        "Evidence detail": "Large population analysis found proposed pathogenic genotypes at 4.705% in gnomAD males and 0.089% in gnomAD females, with similar expanded alleles in HPRC long-read data; these frequencies greatly exceed DMD prevalence, supporting the conclusion that the repeat expansion is unlikely to be pathogenic.",
+        "evidence_category": "Collective Evidence",
+        "evidence_supercategory": "Genetic Evidence",
+        "evidence_max_score": 3,
+        "category_max_score": 3,
+        "publication_dates": [
+          "2025-03-26"
+        ]
+      }
+    ],
+    "experimental_evidence_details": [],
+    "category_summary": {
+      "Singular Evidence": 0,
+      "Collective Evidence": 0,
+      "Statistics": 0,
+      "Function": 0,
+      "Functional Alteration": 0,
+      "Models": 0,
+      "Rescue": 0
+    },
+    "supercategory_summary": {
+      "Genetic Evidence": 0,
+      "Experimental Evidence": 0
+    },
+    "total_score": 0,
+    "publication_count": 2,
+    "publication_interval_years": 8.65,
+    "classification": "Refuted"
+  }
+],
 {
   "Disease_ID": "DM1",
   "Gene": "DMPK",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -2254,8 +2254,7 @@
   "publication_interval_years": 0.99,
   "classification": "Strong"
 },
-[
-  {
+{
     "Disease_ID": "DMD",
     "Gene": "DMD",
     "Locus_ID": "DMD_DMD",
@@ -2312,8 +2311,7 @@
     "publication_count": 2,
     "publication_interval_years": 8.65,
     "classification": "Refuted"
-  }
-],
+},
 {
   "Disease_ID": "DM1",
   "Gene": "DMPK",


### PR DESCRIPTION
## Description

Updated the criTRia evidence details and root-level description for the **DMD_DMD** locus curation. The update clarifies the evidence supporting the current **Refuted** classification: the original report described a single family with a DMD intron 62 GAA expansion, while later population-level data showed the proposed pathogenic genotype is too frequent to support a highly penetrant early-onset X-linked disease association.

Fixes: # **Link to any relevant issues and/or discussions**

## Major Changes

* None.

## Minor Changes

* Updated the root-level `Description` for **DMD_DMD** to better summarize the conflicting evidence and refuted classification.
* Revised the `Probands` evidence detail for `pmid:27417533` to specify that the report involved a single three-generation family and that the phenotypic impact remained unresolved.
* Revised the `Computational` evidence detail for `pmid:40140942` to include population-frequency evidence supporting refutation.
* No scores, evidence rows, summaries, classification, publication count, or publication interval were changed.

## Checklist

* [x] All changes are well summarized
* [ ] Check all tests pass
* [ ] Check that the website preview looks good
* [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
* [ ] Ask someone to review this PR
