### PR TITLE
POLG_CPEO-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4451,82 +4451,92 @@
   "classification": "Moderate"
 },
 {
-  "Disease_ID": "CPEO",
-  "Gene": "POLG",
-  "Locus_ID": "CPEO_POLG",
-  "Inheritance": null,
-  "Curator": "Macayla Weiner, Laurel Hiatt",
-  "Date": "08/18/2025",
-  "Description": "This locus is a proposed modifier to Parkinson's disease and has little evidence supporting it's causative role [@pmid:19043662]. This locus also has conflicting evidence on the association between the repeat and progressive external opthalmoplegia.",
-  "Source": "criTRia",
-  "SOP_version": "criTRia v0",
-  "Manual_evidence_level": "Disputed",
-  "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 6.0,
-    "Citation": "pmid:22963882",
-    "Evidence detail": "191 patients",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2008-12-09"]
-  }],
-  "experimental_evidence_details": [
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:22963882",
-    "Evidence detail": "Evidence of mechanistic relationship between mitochondrial dysfunction and disease biology.",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2008-12-09"]
-  },
-  {
-    "Evidence type": "Protein interaction",
-    "Score": 0.5,
-    "Citation": "pmid:22963882",
-    "Evidence detail": "Altered protien interaction.",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2008-12-09"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:22963882",
-    "Evidence detail": "Evidence of altered expression downstream of the repeat.",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2008-12-09"]
-  }],
-  "category_summary":
-  {
-    "Singular Evidence": 6.0,
-    "Collective Evidence": 0,
-    "Statistics": 0,
-    "Function": 1.5,
-    "Functional Alteration": 0,
-    "Models": 0,
-    "Rescue": 0
-  },
-  "supercategory_summary":
-  {
-    "Experimental Evidence": 1.5,
-    "Genetic Evidence": 6.0
-  },
-  "total_score": 7.5,
-  "publication_count": 1,
-  "publication_interval_years": null,
-  "classification": "Disputed"
-},
+    "Disease_ID": "CPEO",
+    "Gene": "POLG",
+    "Locus_ID": "CPEO_POLG",
+    "Inheritance": null,
+    "Curator": "Macayla Weiner, Laurel Hiatt",
+    "Date": "08/18/2025",
+    "Description": "The curated POLG CAG/polyglutamine repeat has disputed relevance to CPEO. The provided sources evaluate the repeat primarily as a modifier/association signal in Parkinson disease and Friedreich ataxia, and note that pathogenic POLG coding variants can cause progressive external ophthalmoplegia; they do not provide direct evidence that POLG CAG-repeat variation causes CPEO.",
+    "Source": "criTRia",
+    "SOP_version": "criTRia v0",
+    "Manual_evidence_level": "Disputed",
+    "genetic_evidence_details": [
+      {
+        "Evidence type": "Probands",
+        "Score": 6.0,
+        "Citation": "pmid:22963882",
+        "Evidence detail": "Curator review needed: PMID 22963882 reports 191 Parkinson disease cases and 191 controls sequenced for the POLG1 CAG repeat; it does not describe CPEO probands.",
+        "evidence_category": "Singular Evidence",
+        "evidence_supercategory": "Genetic Evidence",
+        "evidence_max_score": 6,
+        "category_max_score": 6,
+        "publication_dates": [
+          "2008-12-09"
+        ]
+      }
+    ],
+    "experimental_evidence_details": [
+      {
+        "Evidence type": "Biochemical function",
+        "Score": 0.5,
+        "Citation": "pmid:22963882",
+        "Evidence detail": "Gene-level evidence: POLG encodes the catalytic subunit of mitochondrial DNA polymerase gamma, which replicates and repairs mtDNA; PMID 22963882 does not provide a CPEO-specific functional assay of the CAG repeat.",
+        "evidence_category": "Function",
+        "evidence_supercategory": "Experimental Evidence",
+        "evidence_max_score": 2,
+        "category_max_score": 2,
+        "publication_dates": [
+          "2008-12-09"
+        ]
+      },
+      {
+        "Evidence type": "Protein interaction",
+        "Score": 0.5,
+        "Citation": "pmid:22963882",
+        "Evidence detail": "Gene-level evidence: polymerase gamma is described as a heterotrimer comprising one POLG1 catalytic subunit and two POLG2 accessory subunits; no CAG-repeat- or CPEO-specific altered interaction is shown.",
+        "evidence_category": "Function",
+        "evidence_supercategory": "Experimental Evidence",
+        "evidence_max_score": 2,
+        "category_max_score": 2,
+        "publication_dates": [
+          "2008-12-09"
+        ]
+      },
+      {
+        "Evidence type": "Regulatory impact",
+        "Score": 0.5,
+        "Citation": "pmid:22963882",
+        "Evidence detail": "Curator review needed: PMID 22963882 cites prior in silico RNA-folding effects for CAG-repeat variants but does not experimentally show repeat-dependent expression, splicing, or epigenetic impact in CPEO.",
+        "evidence_category": "Function",
+        "evidence_supercategory": "Experimental Evidence",
+        "evidence_max_score": 2,
+        "category_max_score": 2,
+        "publication_dates": [
+          "2008-12-09"
+        ]
+      }
+    ],
+    "category_summary": {
+      "Singular Evidence": 6.0,
+      "Collective Evidence": 0,
+      "Statistics": 0,
+      "Function": 1.5,
+      "Functional Alteration": 0,
+      "Models": 0,
+      "Rescue": 0
+    },
+    "supercategory_summary": {
+      "Experimental Evidence": 1.5,
+      "Genetic Evidence": 6.0
+    },
+    "total_score": 7.5,
+    "publication_count": 1,
+    "publication_interval_years": null,
+    "classification": "Disputed"
+  }
+]
+,
 {
   "Disease_ID": "SCA12",
   "Gene": "PPP2R2B",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4466,7 +4466,7 @@
         "Evidence type": "Probands",
         "Score": 6.0,
         "Citation": "pmid:22963882",
-        "Evidence detail": "Curator review needed: PMID 22963882 reports 191 Parkinson disease cases and 191 controls sequenced for the POLG1 CAG repeat; it does not describe CPEO probands.",
+        "Evidence detail": "Reports 191 Parkinson disease cases and 191 controls sequenced for the POLG1 CAG repeat; it does not describe CPEO probands.",
         "evidence_category": "Singular Evidence",
         "evidence_supercategory": "Genetic Evidence",
         "evidence_max_score": 6,
@@ -4502,19 +4502,6 @@
         "publication_dates": [
           "2008-12-09"
         ]
-      },
-      {
-        "Evidence type": "Regulatory impact",
-        "Score": 0.5,
-        "Citation": "pmid:22963882",
-        "Evidence detail": "Curator review needed: PMID 22963882 cites prior in silico RNA-folding effects for CAG-repeat variants but does not experimentally show repeat-dependent expression, splicing, or epigenetic impact in CPEO.",
-        "evidence_category": "Function",
-        "evidence_supercategory": "Experimental Evidence",
-        "evidence_max_score": 2,
-        "category_max_score": 2,
-        "publication_dates": [
-          "2008-12-09"
-        ]
       }
     ],
     "category_summary": {
@@ -4534,10 +4521,8 @@
     "publication_count": 1,
     "publication_interval_years": null,
     "classification": "Disputed"
-  }
-]
-,
-{
+  },
+  {
   "Disease_ID": "SCA12",
   "Gene": "PPP2R2B",
   "Locus_ID": "SCA12_PPP2R2B",

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -4451,78 +4451,72 @@
   "classification": "Moderate"
 },
 {
-    "Disease_ID": "CPEO",
-    "Gene": "POLG",
-    "Locus_ID": "CPEO_POLG",
-    "Inheritance": null,
-    "Curator": "Macayla Weiner, Laurel Hiatt",
-    "Date": "08/18/2025",
-    "Description": "The curated POLG CAG/polyglutamine repeat has disputed relevance to CPEO. The provided sources evaluate the repeat primarily as a modifier/association signal in Parkinson disease and Friedreich ataxia, and note that pathogenic POLG coding variants can cause progressive external ophthalmoplegia; they do not provide direct evidence that POLG CAG-repeat variation causes CPEO.",
-    "Source": "criTRia",
-    "SOP_version": "criTRia v0",
-    "Manual_evidence_level": "Disputed",
-    "genetic_evidence_details": [
-      {
-        "Evidence type": "Probands",
-        "Score": 6.0,
-        "Citation": "pmid:22963882",
-        "Evidence detail": "Reports 191 Parkinson disease cases and 191 controls sequenced for the POLG1 CAG repeat; it does not describe CPEO probands.",
-        "evidence_category": "Singular Evidence",
-        "evidence_supercategory": "Genetic Evidence",
-        "evidence_max_score": 6,
-        "category_max_score": 6,
-        "publication_dates": [
-          "2008-12-09"
-        ]
-      }
-    ],
-    "experimental_evidence_details": [
-      {
-        "Evidence type": "Biochemical function",
-        "Score": 0.5,
-        "Citation": "pmid:22963882",
-        "Evidence detail": "Gene-level evidence: POLG encodes the catalytic subunit of mitochondrial DNA polymerase gamma, which replicates and repairs mtDNA; PMID 22963882 does not provide a CPEO-specific functional assay of the CAG repeat.",
-        "evidence_category": "Function",
-        "evidence_supercategory": "Experimental Evidence",
-        "evidence_max_score": 2,
-        "category_max_score": 2,
-        "publication_dates": [
-          "2008-12-09"
-        ]
-      },
-      {
-        "Evidence type": "Protein interaction",
-        "Score": 0.5,
-        "Citation": "pmid:22963882",
-        "Evidence detail": "Gene-level evidence: polymerase gamma is described as a heterotrimer comprising one POLG1 catalytic subunit and two POLG2 accessory subunits; no CAG-repeat- or CPEO-specific altered interaction is shown.",
-        "evidence_category": "Function",
-        "evidence_supercategory": "Experimental Evidence",
-        "evidence_max_score": 2,
-        "category_max_score": 2,
-        "publication_dates": [
-          "2008-12-09"
-        ]
-      }
-    ],
-    "category_summary": {
-      "Singular Evidence": 6.0,
-      "Collective Evidence": 0,
-      "Statistics": 0,
-      "Function": 1.5,
-      "Functional Alteration": 0,
-      "Models": 0,
-      "Rescue": 0
-    },
-    "supercategory_summary": {
-      "Experimental Evidence": 1.5,
-      "Genetic Evidence": 6.0
-    },
-    "total_score": 7.5,
-    "publication_count": 1,
-    "publication_interval_years": null,
-    "classification": "Disputed"
+  "Disease_ID": "CPEO",
+  "Gene": "POLG",
+  "Locus_ID": "CPEO_POLG",
+  "Inheritance": null,
+  "Curator": "Macayla Weiner, Laurel Hiatt",
+  "Date": "08/18/2025",
+  "Description": "The curated POLG CAG/polyglutamine repeat has disputed relevance to CPEO. The provided sources evaluate the repeat primarily as a modifier/association signal in Parkinson disease and Friedreich ataxia, and note that pathogenic POLG coding variants can cause progressive external ophthalmoplegia; they do not provide direct evidence that POLG CAG-repeat variation causes CPEO.",
+  "Source": "criTRia",
+  "SOP_version": "criTRia v0",
+  "Manual_evidence_level": "Disputed",
+  "genetic_evidence_details": [
+  {
+    "Evidence type": "Probands",
+    "Score": 6.0,
+    "Citation": "pmid:22963882",
+    "Evidence detail": "Reports 191 Parkinson disease cases and 191 controls sequenced for the POLG1 CAG repeat; it does not describe CPEO probands.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2008-12-09"]
+  }],
+  "experimental_evidence_details": [
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:22963882",
+    "Evidence detail": "Gene-level evidence: POLG encodes the catalytic subunit of mitochondrial DNA polymerase gamma, which replicates and repairs mtDNA; PMID 22963882 does not provide a CPEO-specific functional assay of the CAG repeat.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2008-12-09"]
   },
   {
+    "Evidence type": "Protein interaction",
+    "Score": 0.5,
+    "Citation": "pmid:22963882",
+    "Evidence detail": "Gene-level evidence: polymerase gamma is described as a heterotrimer comprising one POLG1 catalytic subunit and two POLG2 accessory subunits; no CAG-repeat- or CPEO-specific altered interaction is shown.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2008-12-09"]
+  }],
+  "category_summary":
+  {
+    "Singular Evidence": 6.0,
+    "Collective Evidence": 0,
+    "Statistics": 0,
+    "Function": 1.0,
+    "Functional Alteration": 0,
+    "Models": 0,
+    "Rescue": 0
+  },
+  "supercategory_summary":
+  {
+    "Experimental Evidence": 1.0,
+    "Genetic Evidence": 6.0
+  },
+  "total_score": 7.0,
+  "publication_count": 1,
+  "publication_interval_years": null,
+  "classification": "Disputed"
+},
+{
   "Disease_ID": "SCA12",
   "Gene": "PPP2R2B",
   "Locus_ID": "SCA12_PPP2R2B",


### PR DESCRIPTION
## Description

Update the POLG_CPEO criTRia entry to clarify evidence details and flag items that need curator review. The reviewed sources support Parkinson disease association/modifier evidence and gene-level POLG biology, but do not clearly support a CPEO-specific causal relationship for the POLG CAG/polyglutamine repeat.

Fixes: https://github.com/dashnowlab/STRchive/issues/465

## Major Changes

- None.

## Minor Changes

- Updated vague evidence details for the POLG_CPEO entry.
- Added curator-review language for evidence rows not directly supported as CPEO-specific POLG CAG-repeat evidence.
- Clarified that some experimental evidence is gene-level POLG biology rather than tandem-repeat/locus-specific evidence.
- Updated the root-level Description to reflect the disputed status and lack of direct CPEO-specific repeat evidence in the reviewed sources.

## Curator Review Needed

- **Probands / pmid:22963882**
  - This source describes 191 Parkinson disease cases and 191 controls sequenced for the POLG1 CAG repeat.
  - It does not describe CPEO probands.
  - Review whether this row should remain scored as CPEO proband evidence.

- **Regulatory impact / pmid:22963882**
  - The source discusses possible repeat-related effects but does not experimentally demonstrate CPEO-specific repeat-dependent expression, splicing, or epigenetic impact.
  - Review whether this evidence type and score are appropriate.
https://github.com/dashnowlab/STRchive/issues/465
## Gene-Level Evidence

- **Biochemical function / pmid:22963882**
  - POLG encodes mitochondrial DNA polymerase gamma, which is relevant to mtDNA replication/repair.
  - This is gene-level evidence, not direct POLG CAG-repeat evidence for CPEO.

- **Protein interaction / pmid:22963882**
  - Polymerase gamma is described as a POLG1/POLG2 protein complex.
  - This supports gene-level protein-complex biology but does not show altered interaction caused by the CAG repeat in CPEO.
https://github.com/dashnowlab/STRchive/issues/465
## Checklist

- [ ] All changes are well summarized
- [ ] Curator confirms whether PD association evidence should be retained in a CPEO locus curation
- [ ] Curator confirms whether gene-level POLG biology should remain scored as experimental evidence
- [ ] Curator confirms whether the regulatory impact row is supported
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR