### PR TITLE
XLID_SOX3-critria-update

### DIFF
--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5672,88 +5672,75 @@
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-    {
-      "Evidence type": "Probands",
-      "Score": 1.5,
-      "Citation": "pmid:24346842",
-      "Evidence detail": "One male proband with molecularly confirmed Kabuki syndrome and CPHD carried a hemizygous 21-bp SOX3 polyalanine-tract deletion (p.Ala239_245del7A); the SOX3 deletion was maternally inherited, while a separate MLL2 variant was de novo.",
-      "evidence_category": "Singular Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 6,
-      "category_max_score": 6,
-      "publication_dates": [
-        "2025-06-12"
-      ]
-    },
-    {
-      "Evidence type": "Segregation",
-      "Score": 1.5,
-      "Citation": "pmid:19654509",
-      "Evidence detail": "One family with three affected males carrying a 21-bp in-frame SOX3 polyalanine expansion (+7 alanines) segregating with GH deficiency through carrier females; LOD = 2.68 and the expansion was absent from 100 control females.",
-      "evidence_category": "Collective Evidence",
-      "evidence_supercategory": "Genetic Evidence",
-      "evidence_max_score": 3,
-      "category_max_score": 3,
-      "publication_dates": [
-        "2024-07-27"
-      ]
-    }
-  ],
+  {
+    "Evidence type": "Probands",
+    "Score": 1.5,
+    "Citation": "pmid:24346842",
+    "Evidence detail": "One male proband with molecularly confirmed Kabuki syndrome and CPHD carried a hemizygous 21-bp SOX3 polyalanine-tract deletion (p.Ala239_245del7A); the SOX3 deletion was maternally inherited, while a separate MLL2 variant was de novo.",
+    "evidence_category": "Singular Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 6,
+    "category_max_score": 6,
+    "publication_dates": ["2025-06-12"]
+  },
+  {
+    "Evidence type": "Segregation",
+    "Score": 1.5,
+    "Citation": "pmid:19654509",
+    "Evidence detail": "One family with three affected males carrying a 21-bp in-frame SOX3 polyalanine expansion (+7 alanines) segregating with GH deficiency through carrier females; LOD = 2.68 and the expansion was absent from 100 control females.",
+    "evidence_category": "Collective Evidence",
+    "evidence_supercategory": "Genetic Evidence",
+    "evidence_max_score": 3,
+    "category_max_score": 3,
+    "publication_dates": ["2024-07-27"]
+  }],
   "experimental_evidence_details": [
-    {
-      "Evidence type": "Cell culture",
-      "Score": 1.0,
-      "Citation": "pmid:30488659",
-      "Evidence detail": "Curator review needed: cited source describes CSNK1E epileptic encephalopathy and does not support SOX3 locus-specific cell-culture evidence.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2018-10-28"
-      ]
-    },
-    {
-      "Evidence type": "Regulatory impact",
-      "Score": 0.5,
-      "Citation": "pmid:17127446",
-      "Evidence detail": "SOX3 polyalanine expansion mutants showed impaired transcriptional activation and reduced repression of β-catenin/TCF-mediated transcription in reporter assays.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-07-27"
-      ]
-    },
-    {
-      "Evidence type": "Biochemical function",
-      "Score": 0.5,
-      "Citation": "pmid:17127446",
-      "Evidence detail": "SOX3 +7 and +11 alanine expansion proteins formed cytoplasmic and nuclear aggregates, including aggresome-like perinuclear aggregates, in transfected cell systems and chick neural explants.",
-      "evidence_category": "Function",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 2,
-      "category_max_score": 2,
-      "publication_dates": [
-        "2024-07-27"
-      ]
-    },
-    {
-      "Evidence type": "Non-human model organism",
-      "Score": 1.0,
-      "Citation": "pmid:23505376",
-      "Evidence detail": "Sox3-26ala mouse/ES-cell model showed markedly reduced nuclear SOX3 protein, pituitary-region developmental abnormalities, no detectable in vivo aggregates, and a partial loss-of-function mechanism.",
-      "evidence_category": "Models",
-      "evidence_supercategory": "Experimental Evidence",
-      "evidence_max_score": 4,
-      "category_max_score": 4,
-      "publication_dates": [
-        "2024-07-27"
-      ]
-    }
-  ],
-  "category_summary": {
+  {
+    "Evidence type": "Cell culture",
+    "Score": 1.0,
+    "Citation": "pmid:30488659",
+    "Evidence detail": "Curator review needed: cited source describes CSNK1E epileptic encephalopathy and does not support SOX3 locus-specific cell-culture evidence.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2018-10-28"]
+  },
+  {
+    "Evidence type": "Regulatory impact",
+    "Score": 0.5,
+    "Citation": "pmid:17127446",
+    "Evidence detail": "SOX3 polyalanine expansion mutants showed impaired transcriptional activation and reduced repression of β-catenin/TCF-mediated transcription in reporter assays.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-07-27"]
+  },
+  {
+    "Evidence type": "Biochemical function",
+    "Score": 0.5,
+    "Citation": "pmid:17127446",
+    "Evidence detail": "SOX3 +7 and +11 alanine expansion proteins formed cytoplasmic and nuclear aggregates, including aggresome-like perinuclear aggregates, in transfected cell systems and chick neural explants.",
+    "evidence_category": "Function",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 2,
+    "category_max_score": 2,
+    "publication_dates": ["2024-07-27"]
+  },
+  {
+    "Evidence type": "Non-human model organism",
+    "Score": 1.0,
+    "Citation": "pmid:23505376",
+    "Evidence detail": "Sox3-26ala mouse/ES-cell model showed markedly reduced nuclear SOX3 protein, pituitary-region developmental abnormalities, no detectable in vivo aggregates, and a partial loss-of-function mechanism.",
+    "evidence_category": "Models",
+    "evidence_supercategory": "Experimental Evidence",
+    "evidence_max_score": 4,
+    "category_max_score": 4,
+    "publication_dates": ["2024-07-27"]
+  }],
+  "category_summary":
+  {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -5762,7 +5749,8 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary": {
+  "supercategory_summary":
+  {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 3.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5735,17 +5735,17 @@
     "Statistics": 0,
     "Function": 1.0,
     "Functional Alteration": 0,
-    "Models": 2.0,
+    "Models": 1.0,
     "Rescue": 0
   },
   "supercategory_summary":
   {
-    "Experimental Evidence": 3.0,
+    "Experimental Evidence": 2.0,
     "Genetic Evidence": 3.0
   },
-  "total_score": 6.0,
-  "publication_count": 5,
-  "publication_interval_years": 6.62,
+  "total_score": 5.0,
+  "publication_count": 4,
+  "publication_interval_years": 0.88,
   "classification": "Limited"
 },
 {

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5667,80 +5667,93 @@
   "Inheritance": "XR",
   "Curator": "Laurel Hiatt, Macayla Weiner, Harriet Dashnow",
   "Date": "05/14/2026",
-  "Description": "Patients have been reported with a repeat mutation in SOX3, caused by overexpression, downstream decrease in protein levels, and dysregulation. 5 total patients across 2 papers and a mouse model. SOX3 has previously been curated by the ClinGen Syndromic Disorders GCEP (08/02/2023) for [SOX3-related X-linked pituitary hormone deficiency with or without intellectual developmental disorder](https://search.clinicalgenome.org/CCID:006253).",
+  "Description": "Patients have been reported with SOX3 polyalanine repeat mutations associated with X-linked pituitary hormone deficiency with or without intellectual disability, with functional studies showing altered transactivation, protein aggregation in overexpression systems, and reduced SOX3 protein levels in a mouse expansion model. 5 total patients across 2 papers and a mouse model. SOX3 has previously been curated by the ClinGen Syndromic Disorders GCEP (08/02/2023) for [SOX3-related X-linked pituitary hormone deficiency with or without intellectual developmental disorder](https://search.clinicalgenome.org/CCID:006253).",
   "Source": "criTRia",
   "SOP_version": "criTRia v0",
   "Manual_evidence_level": null,
   "genetic_evidence_details": [
-  {
-    "Evidence type": "Probands",
-    "Score": 1.5,
-    "Citation": "pmid:24346842",
-    "Evidence detail": "1 male proband with molcularly confirmed Kabuki syndrome and functional and de novo evidence.",
-    "evidence_category": "Singular Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 6,
-    "category_max_score": 6,
-    "publication_dates": ["2025-06-12"]
-  },
-  {
-    "Evidence type": "Segregation",
-    "Score": 1.5,
-    "Citation": "pmid:19654509",
-    "Evidence detail": "Studied one family with 4 affected individuals and 14 unaffected. LOD = 4.2.",
-    "evidence_category": "Collective Evidence",
-    "evidence_supercategory": "Genetic Evidence",
-    "evidence_max_score": 3,
-    "category_max_score": 3,
-    "publication_dates": ["2024-07-27"]
-  }],
+    {
+      "Evidence type": "Probands",
+      "Score": 1.5,
+      "Citation": "pmid:24346842",
+      "Evidence detail": "One male proband with molecularly confirmed Kabuki syndrome and CPHD carried a hemizygous 21-bp SOX3 polyalanine-tract deletion (p.Ala239_245del7A); the SOX3 deletion was maternally inherited, while a separate MLL2 variant was de novo.",
+      "evidence_category": "Singular Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 6,
+      "category_max_score": 6,
+      "publication_dates": [
+        "2025-06-12"
+      ]
+    },
+    {
+      "Evidence type": "Segregation",
+      "Score": 1.5,
+      "Citation": "pmid:19654509",
+      "Evidence detail": "One family with three affected males carrying a 21-bp in-frame SOX3 polyalanine expansion (+7 alanines) segregating with GH deficiency through carrier females; LOD = 2.68 and the expansion was absent from 100 control females.",
+      "evidence_category": "Collective Evidence",
+      "evidence_supercategory": "Genetic Evidence",
+      "evidence_max_score": 3,
+      "category_max_score": 3,
+      "publication_dates": [
+        "2024-07-27"
+      ]
+    }
+  ],
   "experimental_evidence_details": [
-  {
-    "Evidence type": "Cell culture",
-    "Score": 1.0,
-    "Citation": "pmid:30488659",
-    "Evidence detail": "Decreased expression and significant hypermethylation.",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2018-10-28"]
-  },
-  {
-    "Evidence type": "Regulatory impact",
-    "Score": 0.5,
-    "Citation": "pmid:17127446",
-    "Evidence detail": "Overexpression inhibits downstream signaling.",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-07-27"]
-  },
-  {
-    "Evidence type": "Biochemical function",
-    "Score": 0.5,
-    "Citation": "pmid:17127446",
-    "Evidence detail": "The paper examines the aggregation of mutant SOX3 proteins, their subcellular localization, and the formation of aggresomes.",
-    "evidence_category": "Function",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2024-07-27"]
-  },
-  {
-    "Evidence type": "Non-human model organism",
-    "Score": 1.0,
-    "Citation": "pmid:23505376",
-    "Evidence detail": "Mouse model used to gain mechanistic insights for models with phenotype.",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 4,
-    "category_max_score": 4,
-    "publication_dates": ["2024-07-27"]
-  }],
-  "category_summary":
-  {
+    {
+      "Evidence type": "Cell culture",
+      "Score": 1.0,
+      "Citation": "pmid:30488659",
+      "Evidence detail": "Curator review needed: cited source describes CSNK1E epileptic encephalopathy and does not support SOX3 locus-specific cell-culture evidence.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2018-10-28"
+      ]
+    },
+    {
+      "Evidence type": "Regulatory impact",
+      "Score": 0.5,
+      "Citation": "pmid:17127446",
+      "Evidence detail": "SOX3 polyalanine expansion mutants showed impaired transcriptional activation and reduced repression of β-catenin/TCF-mediated transcription in reporter assays.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-07-27"
+      ]
+    },
+    {
+      "Evidence type": "Biochemical function",
+      "Score": 0.5,
+      "Citation": "pmid:17127446",
+      "Evidence detail": "SOX3 +7 and +11 alanine expansion proteins formed cytoplasmic and nuclear aggregates, including aggresome-like perinuclear aggregates, in transfected cell systems and chick neural explants.",
+      "evidence_category": "Function",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 2,
+      "category_max_score": 2,
+      "publication_dates": [
+        "2024-07-27"
+      ]
+    },
+    {
+      "Evidence type": "Non-human model organism",
+      "Score": 1.0,
+      "Citation": "pmid:23505376",
+      "Evidence detail": "Sox3-26ala mouse/ES-cell model showed markedly reduced nuclear SOX3 protein, pituitary-region developmental abnormalities, no detectable in vivo aggregates, and a partial loss-of-function mechanism.",
+      "evidence_category": "Models",
+      "evidence_supercategory": "Experimental Evidence",
+      "evidence_max_score": 4,
+      "category_max_score": 4,
+      "publication_dates": [
+        "2024-07-27"
+      ]
+    }
+  ],
+  "category_summary": {
     "Singular Evidence": 1.5,
     "Collective Evidence": 1.5,
     "Statistics": 0,
@@ -5749,8 +5762,7 @@
     "Models": 2.0,
     "Rescue": 0
   },
-  "supercategory_summary":
-  {
+  "supercategory_summary": {
     "Experimental Evidence": 3.0,
     "Genetic Evidence": 3.0
   },

--- a/data/criTRia-curations.json
+++ b/data/criTRia-curations.json
@@ -5696,17 +5696,6 @@
   }],
   "experimental_evidence_details": [
   {
-    "Evidence type": "Cell culture",
-    "Score": 1.0,
-    "Citation": "pmid:30488659",
-    "Evidence detail": "Curator review needed: cited source describes CSNK1E epileptic encephalopathy and does not support SOX3 locus-specific cell-culture evidence.",
-    "evidence_category": "Models",
-    "evidence_supercategory": "Experimental Evidence",
-    "evidence_max_score": 2,
-    "category_max_score": 2,
-    "publication_dates": ["2018-10-28"]
-  },
-  {
     "Evidence type": "Regulatory impact",
     "Score": 0.5,
     "Citation": "pmid:17127446",


### PR DESCRIPTION
## Description

Updated the SOX3 XLID/PHPX criTRia JSON entry by refining evidence-detail text and the root-level description while preserving the existing schema, scores, evidence rows, summaries, total score, classification, and publication metadata.

Fixes: [#473](https://github.com/dashnowlab/STRchive/issues/473)

## Major Changes

- None

## Minor Changes

- Updated the root-level SOX3 XLID/PHPX description to more accurately describe SOX3 polyalanine repeat mutations and supporting functional evidence.
- Refined existing evidence-detail fields for proband, segregation, regulatory impact, biochemical function, and non-human model organism evidence.
- Flagged one unsupported cell culture evidence row for curator review because the cited PMID appears to describe CSNK1E epileptic encephalopathy rather than SOX3 locus-specific evidence.
https://github.com/dashnowlab/STRchive/issues/473
- No scores, classifications, category summaries, or evidence rows were changed.

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR