### PR TITLE
Use TR Explorer default columns in locus links

### DIFF
--- a/site/src/data/identifiers.ts
+++ b/site/src/data/identifiers.ts
@@ -120,7 +120,7 @@ export const getIdentifiers = (object: Record<string, unknown>) =>
         {
           key: "position_base1_hg38",
           name: "TR Explorer",
-          link: "https://trexplorer.broadinstitute.org/#sc=isPathogenic&sd=DESC&showRs=1&searchQuery=$ID&showColumns=0i1i2i3i4i7i21i17",
+          link: "https://trexplorer.broadinstitute.org/#sc=isPathogenic&sd=DESC&showRs=1&searchQuery=$ID",
           tooltip:
             "An online portal for exploring genome-wide tandem repeat (TR) catalogs",
           info: "https://trexplorer.broadinstitute.org/",


### PR DESCRIPTION
## Description

Drop the `showColumns=0i1i2i3i4i7i21i17` URL param from the TR Explorer links on locus pages, so TR Explorer shows its own default column set instead of a hardcoded subset that was pinned when the links were first added in #234.

Link before:

```
https://trexplorer.broadinstitute.org/#sc=isPathogenic&sd=DESC&showRs=1&searchQuery=$ID&showColumns=0i1i2i3i4i7i21i17
```

Link after:

```
https://trexplorer.broadinstitute.org/#sc=isPathogenic&sd=DESC&showRs=1&searchQuery=$ID
```

The remaining params (sort column, sort direction, show repeat structure, search query) are unchanged.

## Minor Changes

- `site/src/data/identifiers.ts`: remove `showColumns` from the TR Explorer link template

## Checklist

- [x] All changes are well summarized
- [ ] Check all tests pass
- [ ] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [ ] Ask someone to review this PR
