### PR TITLE
Restructure Snakemake for clarity

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -25,11 +25,9 @@ scripts_dir: str = config["scripts_directory"]
 ref_directory: str = config["ref_directory"]
 stages: str = config["stages"]
 
-### IMPORTS ###
-import os
-import re
 
-# Wildcard constraints; should all be alphanumeric
+# Pin the base_dir wildcard to the configured directory so it can't be
+# misinferred from an ambiguous path match in a rule's input/output
 wildcard_constraints:
     base_dir = base_dir
 
@@ -40,7 +38,7 @@ if stages not in ("all", "new-refs", "old-refs", "skip-refs", "quick"):
 _citations = expand("{base_dir}STRchive-citations.json", base_dir = base_dir) \
     if stages in ("all", "new-refs", "old-refs") else []
 
-# Reference alleles depend on the BED/TRGT catalogs, so skip for "quick"
+# Reference alleles require a reference genome download (slow), so skip for "quick"
 _ref_alleles = (
     expand("{base_dir}ref-alleles/ref-alleles.hg19.txt", base_dir = base_dir) +
     expand("{base_dir}ref-alleles/ref-alleles.hg38.txt", base_dir = base_dir) +

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -33,117 +33,60 @@ import re
 wildcard_constraints:
     base_dir = base_dir
 
-if stages == "all" or stages == "new-refs" or stages == "old-refs":
-    rule all:
-        input:
-            # Citations
-            expand("{base_dir}STRchive-citations.json", base_dir = base_dir),
-            # Curations TSV
-            expand("{base_dir}criTRia-curations.tsv", base_dir = base_dir),
-            # TRGT bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.TRGT.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.TRGT.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.TRGT.bed", base_dir = base_dir),
-            # Atarva bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.atarva.bed.gz", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.atarva.bed.gz", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.atarva.bed.gz", base_dir = base_dir),
-            # stranger catalogs
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.stranger.json", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.stranger.json", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.stranger.json", base_dir = base_dir),
-            # Straglr bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.straglr.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.straglr.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.straglr.bed", base_dir = base_dir),
-            # General BED files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.general.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.general.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.general.bed", base_dir = base_dir),
-            # longTR catalog BED files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.longTR.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.longTR.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.longTR.bed", base_dir = base_dir),
-            # Plots
-            # expand("{base_dir}plots/gnomad.json", base_dir = base_dir),
-            expand("{base_dir}plots/age-onset.json", base_dir = base_dir),
-            expand("{base_dir}plots/path-size.json", base_dir = base_dir),
-            # Reference alleles
-            expand("{base_dir}ref-alleles/ref-alleles.hg19.txt", base_dir = base_dir),
-            expand("{base_dir}ref-alleles/ref-alleles.hg38.txt", base_dir = base_dir),
-            expand("{base_dir}ref-alleles/ref-alleles.T2T-chm13.txt", base_dir = base_dir)
-elif stages == "skip-refs":
-    rule all:
-        input:
-            # Curations TSV
-            expand("{base_dir}criTRia-curations.tsv", base_dir = base_dir),
-            # TRGT bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.TRGT.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.TRGT.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.TRGT.bed", base_dir = base_dir),
-            # Atarva bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.atarva.bed.gz", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.atarva.bed.gz", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.atarva.bed.gz", base_dir = base_dir),
-            # stranger catalogs
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.stranger.json", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.stranger.json", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.stranger.json", base_dir = base_dir),
-            # Straglr bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.straglr.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.straglr.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.straglr.bed", base_dir = base_dir),
-            # General BED files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.general.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.general.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.general.bed", base_dir = base_dir),
-            # longTR catalog BED files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.longTR.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.longTR.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.longTR.bed", base_dir = base_dir),
-            # Plots
-            # expand("{base_dir}plots/gnomad.json", base_dir = base_dir),
-            expand("{base_dir}plots/age-onset.json", base_dir = base_dir),
-            expand("{base_dir}plots/path-size.json", base_dir = base_dir),
-            # Reference alleles
-            expand("{base_dir}ref-alleles/ref-alleles.hg19.txt", base_dir = base_dir),
-            expand("{base_dir}ref-alleles/ref-alleles.hg38.txt", base_dir = base_dir),
-            expand("{base_dir}ref-alleles/ref-alleles.T2T-chm13.txt", base_dir = base_dir)
-elif stages == "quick":
-    rule all:
-        input:
-            # Curations TSV
-            expand("{base_dir}criTRia-curations.tsv", base_dir = base_dir),
-            # TRGT bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.TRGT.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.TRGT.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.TRGT.bed", base_dir = base_dir),
-            # Atarva bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.atarva.bed.gz", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.atarva.bed.gz", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.atarva.bed.gz", base_dir = base_dir),
-            # stranger catalogs
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.stranger.json", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.stranger.json", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.stranger.json", base_dir = base_dir),
-            # Straglr bed files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.straglr.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.straglr.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.straglr.bed", base_dir = base_dir),
-            # General BED files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.general.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.general.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.general.bed", base_dir = base_dir),
-            # longTR catalog BED files
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg38.longTR.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.hg19.longTR.bed", base_dir = base_dir),
-            expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.longTR.bed", base_dir = base_dir),
-            # Plots
-            # expand("{base_dir}plots/gnomad.json", base_dir = base_dir),
-            expand("{base_dir}plots/age-onset.json", base_dir = base_dir),
-            expand("{base_dir}plots/path-size.json", base_dir = base_dir)
-else:
+if stages not in ("all", "new-refs", "old-refs", "skip-refs", "quick"):
     raise ValueError("Invalid stages value. Must be 'all', 'new-refs', 'old-refs', 'skip-refs', or 'quick'")
+
+# Citations take hours to generate/update, so skip for "skip-refs" and "quick"
+_citations = expand("{base_dir}STRchive-citations.json", base_dir = base_dir) \
+    if stages in ("all", "new-refs", "old-refs") else []
+
+# Reference alleles depend on the BED/TRGT catalogs, so skip for "quick"
+_ref_alleles = (
+    expand("{base_dir}ref-alleles/ref-alleles.hg19.txt", base_dir = base_dir) +
+    expand("{base_dir}ref-alleles/ref-alleles.hg38.txt", base_dir = base_dir) +
+    expand("{base_dir}ref-alleles/ref-alleles.T2T-chm13.txt", base_dir = base_dir)
+) if stages != "quick" else []
+
+# Downloads phenotype associations from Monarch (network-dependent). 
+# Run with the stages that pull new references so that HPO terms can be checked alongside new literature.
+_hpo_check = ["{base_dir}check-hpo.txt"] if stages in ("all", "new-refs") else []
+
+rule all:
+    input:
+        # Citations
+        _citations,
+        # Curations TSV
+        expand("{base_dir}criTRia-curations.tsv", base_dir = base_dir),
+        # TRGT bed files
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg38.TRGT.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg19.TRGT.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.TRGT.bed", base_dir = base_dir),
+        # Atarva bed files
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg38.atarva.bed.gz", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg19.atarva.bed.gz", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.atarva.bed.gz", base_dir = base_dir),
+        # stranger catalogs
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg38.stranger.json", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg19.stranger.json", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.stranger.json", base_dir = base_dir),
+        # Straglr bed files
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg38.straglr.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg19.straglr.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.straglr.bed", base_dir = base_dir),
+        # General BED files
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg38.general.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg19.general.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.general.bed", base_dir = base_dir),
+        # longTR catalog BED files
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg38.longTR.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.hg19.longTR.bed", base_dir = base_dir),
+        expand("{base_dir}catalogs/STRchive-disease-loci.T2T-chm13.longTR.bed", base_dir = base_dir),
+        # Plots
+        # expand("{base_dir}plots/gnomad.json", base_dir = base_dir),
+        expand("{base_dir}plots/age-onset.json", base_dir = base_dir),
+        expand("{base_dir}plots/path-size.json", base_dir = base_dir),
+        # Reference alleles
+        _ref_alleles
 
 rule check_curations:
     input:
@@ -168,7 +111,6 @@ rule curations_to_tsv:
         """
 
 
-_hpo_check = ["{base_dir}check-hpo.txt"] if stages in ("all", "new-refs") else []
 # Adds HPO terms to the loci JSON in place
 rule add_hpo:
     input:


### PR DESCRIPTION
## Description

Restructure Snakemake so it's clearer which stages/files run with various settings and avoids long repeated lists of files.

I'm not sure I'm entirely happy with this yet. Feedback welcome.

## Minor Changes

- Restructure snakemake for clarity. No change to behavior.

## Checklist

- [x] All changes are well summarized
- [x] Check all tests pass
- [x] Check that the website preview looks good
- [ ] Update the STRchive version in `CITATION.cff`, format X.Y.Z. If any major changes, increment Y. If only minor changes, increment Z. If the breaking change (rare), increment X.
- [x] Ask someone to review this PR